### PR TITLE
feat: allow custom avatar selection

### DIFF
--- a/lib/core/state/avatar_provider.dart
+++ b/lib/core/state/avatar_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'settings_providers.dart';
+
+class AvatarNotifier extends StateNotifier<String?> {
+  AvatarNotifier(this._uid) : super(null) {
+    if (_uid != null) {
+      _load();
+    }
+  }
+
+  final String? _uid;
+  static const _prefix = 'customAvatar_';
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getString('$_prefix$_uid');
+  }
+
+  Future<void> setAvatar(String path) async {
+    if (_uid == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('$_prefix$_uid', path);
+    state = path;
+  }
+
+  Future<void> clearAvatar() async {
+    if (_uid == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('$_prefix$_uid');
+    state = null;
+  }
+}
+
+final avatarProvider =
+    StateNotifierProvider<AvatarNotifier, String?>((ref) {
+  final uid = ref.watch(authStateProvider).value?.uid;
+  return AvatarNotifier(uid);
+});
+

--- a/lib/features/events/presentation/map/widgets/avatar_icon.dart
+++ b/lib/features/events/presentation/map/widgets/avatar_icon.dart
@@ -1,16 +1,21 @@
 // widgets/avatar_icon.dart
+import 'dart:io';
+
 import 'package:firebase_auth/firebase_auth.dart' as fa;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AvatarIcon extends StatefulWidget {
+import '../../../../../core/state/avatar_provider.dart';
+
+class AvatarIcon extends ConsumerStatefulWidget {
   final void Function(bool authed) onTap;
   const AvatarIcon({super.key, required this.onTap});
 
   @override
-  State<AvatarIcon> createState() => _AvatarIconState();
+  ConsumerState<AvatarIcon> createState() => _AvatarIconState();
 }
 
-class _AvatarIconState extends State<AvatarIcon> {
+class _AvatarIconState extends ConsumerState<AvatarIcon> {
   fa.User? _user;
   @override
   void initState() {
@@ -42,14 +47,20 @@ class _AvatarIconState extends State<AvatarIcon> {
 
   @override
   Widget build(BuildContext context) {
+    final customPath = ref.watch(avatarProvider);
+    ImageProvider? img;
+    if (customPath != null && _user != null) {
+      img = FileImage(File(customPath));
+    } else if ((_user?.photoURL?.isNotEmpty ?? false)) {
+      img = NetworkImage(_user!.photoURL!);
+    }
+
     return InkResponse(
       radius: 22,
       onTap: () => widget.onTap(_user != null),
       child: CircleAvatar(
         radius: 16,
-        foregroundImage: (_user?.photoURL?.isNotEmpty ?? false)
-            ? NetworkImage(_user!.photoURL!)
-            : null,
+        foregroundImage: img,
         child: const Icon(Icons.person, size: 18, color: Colors.grey),
       ),
     );

--- a/lib/features/profile/presentation/profile/profile_page.dart
+++ b/lib/features/profile/presentation/profile/profile_page.dart
@@ -1,14 +1,20 @@
-import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart' as fa;
+import 'dart:io';
 
-class ProfilePage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fa;
+import 'package:image_picker/image_picker.dart';
+
+import '../../../../../core/state/avatar_provider.dart';
+
+class ProfilePage extends ConsumerStatefulWidget {
   const ProfilePage({super.key});
 
   @override
-  State<ProfilePage> createState() => _ProfilePageState();
+  ConsumerState<ProfilePage> createState() => _ProfilePageState();
 }
 
-class _ProfilePageState extends State<ProfilePage> {
+class _ProfilePageState extends ConsumerState<ProfilePage> {
   fa.User? _user;
 
   @override
@@ -123,12 +129,12 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 }
 
-class _ProfileHeader extends StatelessWidget {
+class _ProfileHeader extends ConsumerWidget {
   final fa.User? user;
   const _ProfileHeader({this.user});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
 
     if (user == null) {
@@ -137,7 +143,8 @@ class _ProfileHeader extends StatelessWidget {
           padding: const EdgeInsets.all(16),
           child: Row(
             children: [
-              const CircleAvatar(radius: 32, child: Icon(Icons.person, size: 32)),
+              const CircleAvatar(
+                  radius: 32, child: Icon(Icons.person, size: 32)),
               const SizedBox(width: 16),
               Expanded(
                 child: Column(
@@ -162,19 +169,26 @@ class _ProfileHeader extends StatelessWidget {
       );
     }
 
+    final customPath = ref.watch(avatarProvider);
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Row(
           children: [
-            CircleAvatar(
-              radius: 32,
-              backgroundImage: user!.photoURL != null
-                  ? NetworkImage(user!.photoURL!)
-                  : null,
-              child: user!.photoURL == null
-                  ? const Icon(Icons.person, size: 32)
-                  : null,
+            GestureDetector(
+              onTap: () => _onAvatarTap(context, ref),
+              child: CircleAvatar(
+                radius: 32,
+                foregroundImage: customPath != null
+                    ? FileImage(File(customPath))
+                    : (user!.photoURL != null
+                        ? NetworkImage(user!.photoURL!)
+                        : null),
+                child: (customPath == null && user!.photoURL == null)
+                    ? const Icon(Icons.person, size: 32)
+                    : null,
+              ),
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -193,5 +207,37 @@ class _ProfileHeader extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _onAvatarTap(BuildContext context, WidgetRef ref) async {
+    if (user == null) return;
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (c) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: const Text('替换'),
+              onTap: () => Navigator.pop(c, 'replace'),
+            ),
+            if (ref.read(avatarProvider) != null)
+              ListTile(
+                title: const Text('恢复默认'),
+                onTap: () => Navigator.pop(c, 'remove'),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (action == 'replace') {
+      final picker = ImagePicker();
+      final img = await picker.pickImage(source: ImageSource.gallery);
+      if (img != null) {
+        await ref.read(avatarProvider.notifier).setAvatar(img.path);
+      }
+    } else if (action == 'remove') {
+      await ref.read(avatarProvider.notifier).clearAvatar();
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   cached_network_image: ^3.4.1
   provider: ^6.1.5+1
   flutter_riverpod: ^2.6.1
+  image_picker: ^1.1.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- allow users to replace third-party avatars with custom images
- persist custom avatar by user and reuse across widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e349c540832c8139b247a6d86991