### PR TITLE
Enhance user event page navigation to group chat

### DIFF
--- a/lib/app/main.dart
+++ b/lib/app/main.dart
@@ -58,7 +58,27 @@ class MyApp extends ConsumerWidget {
         '/profile': (context) => ProfilePage(),
         '/history': (context) => HistoryPage(),
         '/favorites': (context) => FavoritesPage(),
-        '/chat': (context) => const UserChatScreen(),
+        '/chat': (context) {
+          final args = ModalRoute.of(context)?.settings.arguments;
+          String? title;
+          String? status;
+          List<String>? tags;
+
+          if (args is Map) {
+            title = args['title'] as String?;
+            status = args['status'] as String?;
+            final rawTags = args['tags'];
+            if (rawTags is List) {
+              tags = rawTags.whereType<String>().toList();
+            }
+          }
+
+          return UserChatScreen(
+            chatTitle: title,
+            chatStatus: status,
+            tags: tags,
+          );
+        },
       },
     );
   }

--- a/lib/playground/chat/presentation/user_chat_screen.dart
+++ b/lib/playground/chat/presentation/user_chat_screen.dart
@@ -4,7 +4,11 @@ import 'package:crew_app/playground/chat/widgets/recent_chats.dart';
 import 'package:flutter/material.dart';
 
 class UserChatScreen extends StatefulWidget {
-  const UserChatScreen({super.key});
+  const UserChatScreen({super.key, this.chatTitle, this.chatStatus, this.tags});
+
+  final String? chatTitle;
+  final String? chatStatus;
+  final List<String>? tags;
 
   @override
   UserChatScreenState createState() => UserChatScreenState();
@@ -23,7 +27,7 @@ class UserChatScreenState extends State<UserChatScreen> {
           onPressed: () {},
         ),
         title: Text(
-          'Chats',
+          widget.chatTitle ?? 'Chats',
           style: TextStyle(
             fontSize: 28.0,
             fontWeight: FontWeight.bold,
@@ -53,12 +57,89 @@ class UserChatScreenState extends State<UserChatScreen> {
               ),
               child: Column(
                 children: <Widget>[
+                  if (widget.chatStatus != null || (widget.tags?.isNotEmpty ?? false))
+                    _EventChatHeader(
+                      status: widget.chatStatus,
+                      tags: widget.tags,
+                    ),
                   FavoriteContacts(),
                   RecentChats(),
                 ],
               ),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventChatHeader extends StatelessWidget {
+  const _EventChatHeader({this.status, this.tags});
+
+  final String? status;
+  final List<String>? tags;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final hasTags = tags != null && tags!.isNotEmpty;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(24),
+          topRight: Radius.circular(24),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: cs.shadow.withValues(alpha: 0.1),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (status != null)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: cs.primaryContainer,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Text(
+                status!,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: cs.onPrimaryContainer,
+                ),
+              ),
+            ),
+          if (hasTags) ...[
+            if (status != null) const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 6,
+              children: tags!
+                  .map(
+                    (tag) => Chip(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      backgroundColor: cs.surfaceVariant,
+                      side: BorderSide.none,
+                      label: Text(
+                        '#$tag',
+                        style: TextStyle(color: cs.onSurfaceVariant),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add category filtering, empty states, and chat navigation to the user events page
- forward event metadata into the chat route and surface the context inside the chat screen header
- allow the global chat route to accept optional arguments for event-aware navigation

## Testing
- not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc740d5d94832c91efe107f86f5758