### PR TITLE
feat: add teams-style group chat experience

### DIFF
--- a/lib/features/chat/group_chat/presentation/group_chat_page.dart
+++ b/lib/features/chat/group_chat/presentation/group_chat_page.dart
@@ -1,0 +1,519 @@
+import 'package:crew_app/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+class GroupChatPage extends StatefulWidget {
+  const GroupChatPage({
+    super.key,
+    required this.channelTitle,
+    required this.currentUser,
+    required this.participants,
+    required this.initialMessages,
+  });
+
+  final String channelTitle;
+  final GroupParticipant currentUser;
+  final List<GroupParticipant> participants;
+  final List<GroupMessage> initialMessages;
+
+  @override
+  State<GroupChatPage> createState() => _GroupChatPageState();
+}
+
+class _GroupChatPageState extends State<GroupChatPage> {
+  late final TextEditingController _composerController;
+  late final ScrollController _scrollController;
+  late final List<GroupMessage> _messages;
+
+  @override
+  void initState() {
+    super.initState();
+    _composerController = TextEditingController();
+    _scrollController = ScrollController();
+    _messages = List<GroupMessage>.of(widget.initialMessages);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+  }
+
+  @override
+  void dispose() {
+    _composerController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _handleSend() {
+    final raw = _composerController.text.trim();
+    if (raw.isEmpty) return;
+    final timeLabel = MaterialLocalizations.of(context)
+        .formatTimeOfDay(TimeOfDay.fromDateTime(DateTime.now()));
+    setState(() {
+      _messages.add(
+        GroupMessage(
+          sender: widget.currentUser,
+          content: raw,
+          timeLabel: timeLabel,
+        ),
+      );
+    });
+    _composerController.clear();
+    _scrollToBottom();
+  }
+
+  void _scrollToBottom() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent + 72,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final participants = [
+      ...widget.participants,
+      if (!widget.participants
+          .any((element) => element.name == widget.currentUser.name))
+        widget.currentUser,
+    ];
+
+    return Scaffold(
+      backgroundColor: cs.surface,
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: cs.surface,
+        foregroundColor: cs.onSurface,
+        titleSpacing: 16,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.channelTitle,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              loc.chatMembersCount(participants.length),
+              style: TextStyle(
+                fontSize: 13,
+                color: cs.onSurfaceVariant,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {},
+          ),
+          IconButton(
+            icon: const Icon(Icons.more_vert),
+            onPressed: () {},
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(72),
+          child: SizedBox(
+            height: 72,
+            child: ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              scrollDirection: Axis.horizontal,
+              itemBuilder: (context, index) {
+                final participant = participants[index];
+                return _ParticipantAvatar(participant: participant);
+              },
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemCount: participants.length,
+            ),
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerLowest,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(24),
+                  topRight: Radius.circular(24),
+                ),
+              ),
+              child: ListView.builder(
+                controller: _scrollController,
+                padding: const EdgeInsets.only(bottom: 24, top: 16),
+                itemCount: _messages.length,
+                itemBuilder: (context, index) {
+                  final msg = _messages[index];
+                  final bool showAvatar = index == 0
+                      ? true
+                      : !_messages[index - 1]
+                          .isFromSameSender(_messages[index]);
+                  return _GroupMessageTile(
+                    message: msg,
+                    showAvatar: showAvatar,
+                    youLabel: loc.chatYouLabel,
+                    repliesLabelBuilder: loc.chatReplyCount,
+                  );
+                },
+              ),
+            ),
+          ),
+          _MessageComposer(
+            controller: _composerController,
+            hintText: loc.chatMessageInputHint,
+            onSend: _handleSend,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class GroupParticipant {
+  const GroupParticipant({
+    required this.name,
+    required this.initials,
+    required this.avatarColor,
+    this.isSelf = false,
+  });
+
+  final String name;
+  final String initials;
+  final Color avatarColor;
+  final bool isSelf;
+}
+
+class GroupMessage {
+  const GroupMessage({
+    required this.sender,
+    required this.content,
+    required this.timeLabel,
+    this.replyCount,
+    this.replyPreview,
+    this.attachmentChips = const <String>[],
+  });
+
+  final GroupParticipant sender;
+  final String content;
+  final String timeLabel;
+  final int? replyCount;
+  final String? replyPreview;
+  final List<String> attachmentChips;
+
+  bool get isMine => sender.isSelf;
+
+  bool isFromSameSender(GroupMessage other) => sender.name == other.sender.name;
+}
+
+class _ParticipantAvatar extends StatelessWidget {
+  const _ParticipantAvatar({required this.participant});
+
+  final GroupParticipant participant;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final borderColor = participant.isSelf ? cs.primary : cs.surface;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: borderColor, width: participant.isSelf ? 2 : 1),
+          ),
+          child: CircleAvatar(
+            radius: 20,
+            backgroundColor: participant.avatarColor.withOpacity(.18),
+            child: Text(
+              participant.initials,
+              style: TextStyle(
+                fontWeight: FontWeight.w700,
+                color: participant.avatarColor,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 6),
+        SizedBox(
+          width: 64,
+          child: Text(
+            participant.isSelf ? AppLocalizations.of(context)!.chatYouLabel : participant.name,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GroupMessageTile extends StatelessWidget {
+  const _GroupMessageTile({
+    required this.message,
+    required this.showAvatar,
+    required this.youLabel,
+    required this.repliesLabelBuilder,
+  });
+
+  final GroupMessage message;
+  final bool showAvatar;
+  final String youLabel;
+  final String Function(int) repliesLabelBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isMine = message.isMine;
+    final bubbleColor = isMine ? cs.primary : cs.surface;
+    final textColor = isMine ? cs.onPrimary : cs.onSurface;
+    final captionColor = isMine ? cs.onPrimary.withOpacity(.8) : cs.onSurfaceVariant;
+
+    return Padding(
+      padding: EdgeInsetsDirectional.only(
+        start: isMine ? 80 : 16,
+        end: isMine ? 16 : 80,
+        top: 6,
+        bottom: 6,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment:
+            isMine ? MainAxisAlignment.end : MainAxisAlignment.start,
+        children: [
+          if (!isMine)
+            AnimatedOpacity(
+              duration: const Duration(milliseconds: 200),
+              opacity: showAvatar ? 1 : 0,
+              child: showAvatar
+                  ? CircleAvatar(
+                      radius: 18,
+                      backgroundColor: message.sender.avatarColor.withOpacity(.15),
+                      child: Text(
+                        message.sender.initials,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: message.sender.avatarColor,
+                        ),
+                      ),
+                    )
+                  : const SizedBox(width: 36),
+            )
+          else
+            const SizedBox(width: 36),
+          const SizedBox(width: 12),
+          Flexible(
+            child: Column(
+              crossAxisAlignment:
+                  isMine ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              children: [
+                Text(
+                  isMine ? '$youLabel · ${message.timeLabel}' : '${message.sender.name} · ${message.timeLabel}',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: captionColor,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  decoration: BoxDecoration(
+                    color: bubbleColor,
+                    borderRadius: BorderRadius.only(
+                      topLeft: const Radius.circular(20),
+                      topRight: const Radius.circular(20),
+                      bottomLeft: Radius.circular(isMine ? 20 : 8),
+                      bottomRight: Radius.circular(isMine ? 8 : 20),
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: cs.shadow.withOpacity(.04),
+                        blurRadius: 6,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    crossAxisAlignment:
+                        isMine ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        message.content,
+                        style: TextStyle(
+                          fontSize: 15,
+                          height: 1.4,
+                          color: textColor,
+                        ),
+                      ),
+                      if (message.attachmentChips.isNotEmpty) ...[
+                        const SizedBox(height: 12),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: message.attachmentChips
+                              .map(
+                                (chip) => Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 10,
+                                    vertical: 6,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: isMine
+                                        ? cs.onPrimary.withOpacity(.12)
+                                        : cs.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        Icons.insert_drive_file_outlined,
+                                        size: 14,
+                                        color: textColor.withOpacity(.85),
+                                      ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        chip,
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.w600,
+                                          color: textColor,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                if (message.replyCount != null && message.replyCount! > 0)
+                  Container(
+                    margin: const EdgeInsets.only(top: 6),
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: cs.surfaceVariant.withOpacity(.3),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.reply_all, size: 16, color: cs.primary),
+                        const SizedBox(width: 6),
+                        Text(
+                          message.replyPreview ?? repliesLabelBuilder(message.replyCount!),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: cs.onSurfaceVariant,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                if (isMine)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Icon(
+                      Icons.done_all,
+                      size: 16,
+                      color: cs.primary,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MessageComposer extends StatelessWidget {
+  const _MessageComposer({
+    required this.controller,
+    required this.hintText,
+    required this.onSend,
+  });
+
+  final TextEditingController controller;
+  final String hintText;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: cs.surface,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: cs.shadow.withOpacity(.06),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              IconButton(
+                tooltip: 'emoji',
+                icon: Icon(Icons.emoji_emotions_outlined, color: cs.primary),
+                onPressed: () {},
+              ),
+              IconButton(
+                tooltip: 'attach',
+                icon: Icon(Icons.attach_file, color: cs.primary),
+                onPressed: () {},
+              ),
+              Expanded(
+                child: TextField(
+                  controller: controller,
+                  minLines: 1,
+                  maxLines: 4,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: InputDecoration(
+                    border: InputBorder.none,
+                    hintText: hintText,
+                  ),
+                  onSubmitted: (_) => onSend(),
+                ),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  color: cs.primary,
+                  shape: BoxShape.circle,
+                ),
+                child: IconButton(
+                  icon: Icon(Icons.send_rounded, color: cs.onPrimary),
+                  onPressed: onSend,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/user_event/prestantion/user_events_page.dart
+++ b/lib/features/chat/user_event/prestantion/user_events_page.dart
@@ -1,3 +1,4 @@
+import 'package:crew_app/features/chat/group_chat/presentation/group_chat_page.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 
@@ -11,68 +12,212 @@ class UserEventsPage extends StatefulWidget {
 class _UserEventsPageState extends State<UserEventsPage> {
   int _tab = 1; // 0=我喜欢的 1=我报名的
 
-  final fakeEvents = [
+  final List<Map<String, Object>> _fakeEvents = [
     {
-      "title": "春天一起去爬山吧！",
-      "status": "报名中",
-      "time": "15:25",
-      "subtitle": "不要忘带保温壶",
-      "tags": ["户外", "运动"],
-      "unread": 3
+      'title': '春天一起去爬山吧！',
+      'status': '报名中',
+      'time': '15:25',
+      'subtitle': '不要忘带保温壶',
+      'tags': ['户外', '运动'],
+      'unread': 3,
     },
     {
-      "title": "线上听歌小组",
-      "status": "进行中",
-      "time": "11:20",
-      "subtitle": "王聪聪：开门！开门！开门！",
-      "tags": ["音乐"],
-      "unread": 2
+      'title': '线上听歌小组',
+      'status': '进行中',
+      'time': '11:20',
+      'subtitle': '王聪聪：开门！开门！开门！',
+      'tags': ['音乐'],
+      'unread': 2,
     },
     {
-      "title": "米兰市区City Walk 2号",
-      "status": "报名中",
-      "time": "16:26",
-      "subtitle": "米兰小巷：我们征集下一条路线~",
-      "tags": ["社交", "旅行"],
-      "unread": 0
+      'title': '米兰市区City Walk 2号',
+      'status': '报名中',
+      'time': '16:26',
+      'subtitle': '米兰小巷：我们征集下一条路线~',
+      'tags': ['社交', '旅行'],
+      'unread': 0,
     },
   ];
 
+  late final GroupParticipant _currentUser = GroupParticipant(
+    name: '我',
+    initials: 'ME',
+    avatarColor: const Color(0xFF6750A4),
+    isSelf: true,
+  );
+
+  late final List<List<GroupParticipant>> _sampleParticipants = [
+    [
+      const GroupParticipant(
+        name: '林雨晴',
+        initials: 'YQ',
+        avatarColor: Color(0xFF6750A4),
+      ),
+      const GroupParticipant(
+        name: 'Marco',
+        initials: 'MA',
+        avatarColor: Color(0xFF4C6ED7),
+      ),
+      const GroupParticipant(
+        name: '王聪聪',
+        initials: 'CC',
+        avatarColor: Color(0xFFE46C5B),
+      ),
+    ],
+    [
+      const GroupParticipant(
+        name: 'Leo',
+        initials: 'LE',
+        avatarColor: Color(0xFF00696B),
+      ),
+      const GroupParticipant(
+        name: 'Cici',
+        initials: 'CI',
+        avatarColor: Color(0xFFD6589F),
+      ),
+      const GroupParticipant(
+        name: 'Hannah',
+        initials: 'HA',
+        avatarColor: Color(0xFFB1974B),
+      ),
+    ],
+    [
+      const GroupParticipant(
+        name: '米兰小巷',
+        initials: 'ML',
+        avatarColor: Color(0xFF2F4858),
+      ),
+      const GroupParticipant(
+        name: 'Francesca',
+        initials: 'FR',
+        avatarColor: Color(0xFFB75F89),
+      ),
+      const GroupParticipant(
+        name: 'Ken',
+        initials: 'KE',
+        avatarColor: Color(0xFF377D71),
+      ),
+    ],
+  ];
+
+  late final List<List<GroupMessage>> _sampleMessages = [
+    [
+      GroupMessage(
+        sender: _sampleParticipants[0][0],
+        content: '周六记得带上登山杖和保温壶，山上还会有些冷。',
+        timeLabel: '09:20',
+        replyCount: 3,
+        replyPreview: '王聪聪：收到！',
+        attachmentChips: const ['行程安排.pdf'],
+      ),
+      GroupMessage(
+        sender: _sampleParticipants[0][2],
+        content: '我可以带两壶热姜茶，大家可以分着喝。',
+        timeLabel: '10:02',
+      ),
+      GroupMessage(
+        sender: _currentUser,
+        content: '太贴心了！下午三点在龙泉寺门口集合哦～',
+        timeLabel: '10:05',
+      ),
+    ],
+    [
+      GroupMessage(
+        sender: _sampleParticipants[1][0],
+        content: '今晚 8 点开始，提前十分钟上线试一下音频～',
+        timeLabel: '15:40',
+        replyCount: 2,
+      ),
+      GroupMessage(
+        sender: _sampleParticipants[1][1],
+        content: '我准备了新的歌单，等会分享链接。',
+        timeLabel: '15:44',
+      ),
+      GroupMessage(
+        sender: _currentUser,
+        content: '我能顺便点几首老歌吗？',
+        timeLabel: '15:46',
+      ),
+    ],
+    [
+      GroupMessage(
+        sender: _sampleParticipants[2][0],
+        content: '路线 2 号有一些石板路，记得穿好走的鞋子。',
+        timeLabel: '08:12',
+        attachmentChips: const ['路线图.png'],
+      ),
+      GroupMessage(
+        sender: _sampleParticipants[2][1],
+        content: '咖啡店会提前预约，大家提前 10 分钟到哦。',
+        timeLabel: '08:21',
+      ),
+      GroupMessage(
+        sender: _currentUser,
+        content: '收到，我顺便把城市探索的新朋友拉进来了。',
+        timeLabel: '08:30',
+      ),
+    ],
+  ];
+
+  void _openChat(Map<String, Object> event, int index) {
+    final participants = _sampleParticipants[index % _sampleParticipants.length];
+    final messages = _sampleMessages[index % _sampleMessages.length];
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => GroupChatPage(
+          channelTitle: event['title'] as String,
+          participants: participants,
+          currentUser: _currentUser,
+          initialMessages: messages,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-        final loc = AppLocalizations.of(context)!;
-    // final cs = Theme.of(context).colorScheme;
+    final loc = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
 
     return Scaffold(
-   appBar: AppBar(centerTitle: true, title: Text(loc.my_events)),
-      body: Container(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text(loc.my_events),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list_alt),
+            tooltip: loc.filter,
+            onPressed: () {},
+          ),
+        ],
+      ),
+      body: DecoratedBox(
         decoration: BoxDecoration(
           image: DecorationImage(
-            image: const AssetImage("assets/images/bg_pattern.png"), // 自己放个淡色图
+            image: const AssetImage('assets/images/bg_pattern.png'),
             fit: BoxFit.cover,
             colorFilter: ColorFilter.mode(
-              Colors.white.withValues(alpha: 0.85),
+              Colors.white.withValues(alpha: 0.9),
               BlendMode.srcATop,
             ),
           ),
         ),
         child: Column(
           children: [
-            // 顶部 Tab
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 12),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   _TabChip(
-              label: loc.events_tab_favorites,
+                    label: loc.events_tab_favorites,
                     selected: _tab == 0,
                     onTap: () => setState(() => _tab = 0),
                     icon: Icons.favorite,
                   ),
                   const SizedBox(width: 12),
                   _TabChip(
-    label: loc.events_tab_registered,
+                    label: loc.events_tab_registered,
                     selected: _tab == 1,
                     onTap: () => setState(() => _tab = 1),
                     icon: Icons.autorenew,
@@ -82,16 +227,21 @@ class _UserEventsPageState extends State<UserEventsPage> {
             ),
             Expanded(
               child: ListView.builder(
-                itemCount: fakeEvents.length,
-                itemBuilder: (context, i) {
-                  final ev = fakeEvents[i];
+                padding: const EdgeInsets.only(bottom: 24),
+                physics: const BouncingScrollPhysics(),
+                itemCount: _fakeEvents.length,
+                itemBuilder: (context, index) {
+                  final ev = _fakeEvents[index];
                   return _EventTile(
-                    title: ev["title"] as String,
-                    subTitle: ev["subtitle"] as String,
-                    status: ev["status"] as String,
-                    timeText: ev["time"] as String,
-                    tags: (ev["tags"] as List).cast<String>(),
-                    unreadCount: ev["unread"] as int,
+                    title: ev['title'] as String,
+                    subTitle: ev['subtitle'] as String,
+                    status: ev['status'] as String,
+                    timeText: ev['time'] as String,
+                    tags: (ev['tags'] as List).cast<String>(),
+                    unreadCount: ev['unread'] as int,
+                    highlightColor: cs.primary,
+                    openChatLabel: loc.eventsOpenChat,
+                    onTap: () => _openChat(ev, index),
                   );
                 },
               ),
@@ -125,7 +275,7 @@ class _TabChip extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: selected ? color.primary : color.surfaceContainerHighest ,
+          color: selected ? color.primary : color.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(24),
         ),
         child: Row(
@@ -151,358 +301,179 @@ class _EventTile extends StatelessWidget {
   const _EventTile({
     required this.title,
     required this.subTitle,
-    this.tags,
+    required this.tags,
+    required this.highlightColor,
+    required this.openChatLabel,
     this.status,
     this.timeText,
     this.unreadCount,
+    this.onTap,
   });
 
   final String title;
   final String subTitle;
-  final List<String>? tags;
+  final List<String> tags;
+  final Color highlightColor;
+  final String openChatLabel;
   final String? status;
   final String? timeText;
   final int? unreadCount;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: cs.outlineVariant.withValues(alpha: .3))),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          CircleAvatar(
-            radius: 22,
-            backgroundColor: cs.surfaceContainerHighest ,
-            child: const Icon(Icons.event, size: 20),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Material(
+        color: cs.surface,
+        elevation: 0,
+        borderRadius: BorderRadius.circular(20),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Text(title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
-                    ),
-                    if (status != null)
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                        margin: const EdgeInsets.only(left: 6),
-                        decoration: BoxDecoration(
-                          color: cs.secondaryContainer,
-                          borderRadius: BorderRadius.circular(12),
+                    Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        CircleAvatar(
+                          radius: 26,
+                          backgroundColor: highlightColor.withOpacity(.12),
+                          child: Icon(Icons.forum_outlined, color: highlightColor),
                         ),
-                        child: Text(status!, style: TextStyle(fontSize: 11, color: cs.onSecondaryContainer)),
+                        if ((unreadCount ?? 0) > 0)
+                          Positioned(
+                            right: -4,
+                            top: -4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: cs.error,
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Text(
+                                unreadCount.toString(),
+                                style: TextStyle(
+                                  color: cs.onError,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                              if (status != null)
+                                Container(
+                                  margin: const EdgeInsets.only(left: 8),
+                                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                  decoration: BoxDecoration(
+                                    color: cs.secondaryContainer,
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Text(
+                                    status!,
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color: cs.onSecondaryContainer,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            subTitle,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant),
+                          ),
+                          if (tags.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Wrap(
+                                spacing: 8,
+                                runSpacing: 6,
+                                children: tags
+                                    .map(
+                                      (tag) => Container(
+                                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                        decoration: BoxDecoration(
+                                          color: cs.surfaceContainerHighest,
+                                          borderRadius: BorderRadius.circular(12),
+                                        ),
+                                        child: Text(
+                                          tag,
+                                          style: TextStyle(fontSize: 11, color: cs.onSurfaceVariant),
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                            ),
+                        ],
                       ),
-                    const SizedBox(width: 8),
-                    Text(timeText ?? '', style: TextStyle(fontSize: 12, color: cs.outline)),
+                    ),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          timeText ?? '',
+                          style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                        ),
+                        const SizedBox(height: 18),
+                        Icon(Icons.arrow_forward_ios_rounded, size: 16, color: cs.onSurfaceVariant.withOpacity(.7)),
+                      ],
+                    ),
                   ],
                 ),
-                const SizedBox(height: 4),
-                Text(subTitle, style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
-                if (tags != null && tags!.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 6),
-                    child: Wrap(
-                      spacing: 6,
-                      children: tags!
-                          .map((e) => Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                                decoration: BoxDecoration(
-                                  color: cs.surfaceContainerHighest ,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Text(e, style: TextStyle(fontSize: 11, color: cs.onSurfaceVariant)),
-                              ))
-                          .toList(),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Icon(Icons.chat_bubble_outline_rounded, size: 18, color: highlightColor),
+                    const SizedBox(width: 6),
+                    Text(
+                      openChatLabel,
+                      style: TextStyle(
+                        color: highlightColor,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
-                  ),
+                    const Spacer(),
+                    Icon(Icons.push_pin_outlined, size: 18, color: cs.onSurfaceVariant.withOpacity(.6)),
+                  ],
+                ),
               ],
             ),
           ),
-          if ((unreadCount ?? 0) > 0)
-            Container(
-              margin: const EdgeInsets.only(left: 8, top: 4),
-              padding: const EdgeInsets.all(6),
-              decoration: BoxDecoration(color: cs.error, shape: BoxShape.circle),
-              child: Text(
-                unreadCount.toString(),
-                style: TextStyle(color: cs.onError, fontSize: 11),
-              ),
-            ),
-        ],
+        ),
       ),
     );
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-// import 'package:crew_app/core/network/api_service.dart';
-// import 'package:crew_app/features/events/data/event.dart';
-// import 'package:crew_app/features/events/presentation/detail/events_detail_page.dart';
-// import 'package:flutter/material.dart';
-
-// class UserEventsPage extends StatefulWidget {
-//   const UserEventsPage({super.key});
-//   @override
-//   State<UserEventsPage> createState() => _EventsListPageState();
-// }
-
-// class _EventsListPageState extends State<UserEventsPage> {
-//   final api = ApiService();
-//   int _tab = 1; // 0=我喜欢的 1=我报名的（仅UI切换，数据过滤按你业务加）
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(centerTitle: true, title: const Text('我的活动')),
-//       body: FutureBuilder<List<Event>>(
-//         future: api.getEvents(),
-//         builder: (context, snap) {
-//           if (snap.connectionState == ConnectionState.waiting) {
-//             return const Center(child: CircularProgressIndicator());
-//           }
-//           if (snap.hasError) return Center(child: Text('Error: ${snap.error}'));
-//           final events = snap.data ?? const <Event>[];
-//           if (events.isEmpty) return const Center(child: Text('暂无活动'));
-
-//           return CustomScrollView(
-//             slivers: [
-//               SliverToBoxAdapter(
-//                 child: Padding(
-//                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-//                   child: Row(
-//                     children: [
-//                       _TabChip(
-//                         label: '我喜欢的',
-//                         selected: _tab == 0,
-//                         onTap: () => setState(() => _tab = 0),
-//                         icon: Icons.favorite,
-//                       ),
-//                       const SizedBox(width: 12),
-//                       _TabChip(
-//                         label: '我报名的',
-//                         selected: _tab == 1,
-//                         onTap: () => setState(() => _tab = 1),
-//                         icon: Icons.autorenew, // 旋转图标的感觉
-//                       ),
-//                     ],
-//                   ),
-//                 ),
-//               ),
-//               SliverList.builder(
-//                 itemCount: events.length,
-//                 itemBuilder: (context, i) {
-//                   final ev = events[i];
-//                   return _EventTile(
-//                     title: ev.title,
-//                     subTitle: ev.location,
-//                     // 以下字段按需映射：若你的 Event 没有就传 null/忽略
-//                     cover: (ev as dynamic).coverUrl,           // String?
-//                     organizer: (ev as dynamic).organizerName,   // String?
-//                     tags: (ev as dynamic).tags as List<String>?,// List<String>?
-//                     status: (ev as dynamic).status,             // 例：'报名中' '进行中' '已结束'
-//                     timeText: (ev as dynamic).timeText,         // 例：'15:25'
-//                     unreadCount: (ev as dynamic).unreadCount,   // int?
-//                     onTap: () => Navigator.push(
-//                       context,
-//                       MaterialPageRoute(builder: (_) => EventDetailPage(event: ev)),
-//                     ),
-//                   );
-//                 },
-//               ),
-//             ],
-//           );
-//         },
-//       ),
-//     );
-//   }
-// }
-
-// /// 顶部 Tab Chip
-// class _TabChip extends StatelessWidget {
-//   const _TabChip({
-//     required this.label,
-//     required this.selected,
-//     required this.onTap,
-//     required this.icon,
-//   });
-//   final String label;
-//   final bool selected;
-//   final VoidCallback onTap;
-//   final IconData icon;
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final color = Theme.of(context).colorScheme;
-//     return InkWell(
-//       borderRadius: BorderRadius.circular(24),
-//       onTap: onTap,
-//       child: Container(
-//         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-//         decoration: BoxDecoration(
-//           color: selected ? color.primary : color.surfaceContainerHighest,
-//           borderRadius: BorderRadius.circular(24),
-//         ),
-//         child: Row(
-//           children: [
-//             Icon(icon, size: 16, color: selected ? color.onPrimary : color.onSurfaceVariant),
-//             const SizedBox(width: 6),
-//             Text(
-//               label,
-//               style: TextStyle(
-//                 fontWeight: FontWeight.w600,
-//                 color: selected ? color.onPrimary : color.onSurface,
-//               ),
-//             ),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }
-
-// /// 单行活动卡片（贴近你截图的结构）
-// class _EventTile extends StatelessWidget {
-//   const _EventTile({
-//     required this.title,
-//     required this.subTitle,
-//     this.cover,
-//     this.organizer,
-//     this.tags,
-//     this.status,
-//     this.timeText,
-//     this.unreadCount,
-//     this.onTap,
-//   });
-
-//   final String title;
-//   final String subTitle;
-//   final String? cover;
-//   final String? organizer;
-//   final List<String>? tags;
-//   final String? status;
-//   final String? timeText;
-//   final int? unreadCount;
-//   final VoidCallback? onTap;
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final cs = Theme.of(context).colorScheme;
-
-//     return InkWell(
-//       onTap: onTap,
-//       child: Container(
-//         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-//         decoration: BoxDecoration(
-//           color: Theme.of(context).colorScheme.surface,
-//         ),
-//         child: Row(
-//           crossAxisAlignment: CrossAxisAlignment.start,
-//           children: [
-//             // 左侧封面/头像
-//             ClipRRect(
-//               borderRadius: BorderRadius.circular(20),
-//               child: SizedBox(
-//                 width: 44,
-//                 height: 44,
-//                 child: cover != null && cover!.isNotEmpty
-//                     ? Image.network(cover!, fit: BoxFit.cover)
-//                     : Container(color: cs.surfaceContainerHighest, child: const Icon(Icons.image, size: 20)),
-//               ),
-//             ),
-//             const SizedBox(width: 12),
-//             // 中间内容
-//             Expanded(
-//               child: Column(
-//                 crossAxisAlignment: CrossAxisAlignment.start,
-//                 children: [
-//                   // 标题 + 状态胶囊
-//                   Row(
-//                     crossAxisAlignment: CrossAxisAlignment.center,
-//                     children: [
-//                       Expanded(
-//                         child: Text(
-//                           title,
-//                           maxLines: 1,
-//                           overflow: TextOverflow.ellipsis,
-//                           style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-//                         ),
-//                       ),
-//                       if (status != null && status!.isNotEmpty)
-//                         Container(
-//                           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-//                           margin: const EdgeInsets.only(left: 6),
-//                           decoration: BoxDecoration(
-//                             color: cs.secondaryContainer,
-//                             borderRadius: BorderRadius.circular(12),
-//                           ),
-//                           child: Text(status!, style: TextStyle(fontSize: 11, color: cs.onSecondaryContainer)),
-//                         ),
-//                       const SizedBox(width: 8),
-//                       // 时间
-//                       Text(timeText ?? '', style: TextStyle(fontSize: 12, color: cs.outline)),
-//                     ],
-//                   ),
-//                   const SizedBox(height: 4),
-//                   // 组织者/副标题
-//                   Text(
-//                     organizer != null && organizer!.isNotEmpty ? organizer! : subTitle,
-//                     maxLines: 1,
-//                     overflow: TextOverflow.ellipsis,
-//                     style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant),
-//                   ),
-//                   const SizedBox(height: 6),
-//                   // 标签
-//                   if (tags != null && tags!.isNotEmpty)
-//                     Wrap(
-//                       spacing: 6,
-//                       runSpacing: -6,
-//                       children: tags!
-//                           .take(3)
-//                           .map((e) => Container(
-//                                 padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-//                                 decoration: BoxDecoration(
-//                                   color: cs.surfaceContainerHighest,
-//                                   borderRadius: BorderRadius.circular(6),
-//                                 ),
-//                                 child: Text(e, style: TextStyle(fontSize: 11, color: cs.onSurfaceVariant)),
-//                               ))
-//                           .toList(),
-//                     ),
-//                 ],
-//               ),
-//             ),
-//             const SizedBox(width: 8),
-//             // 右侧未读气泡
-//             if ((unreadCount ?? 0) > 0)
-//               Badge(
-//                 label: Text('${unreadCount!}'),
-//                 largeSize: 20,
-//               ),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -272,6 +272,12 @@ abstract class AppLocalizations {
   /// **'Event Title'**
   String get event_title_field_label;
 
+  /// No description provided for @events_open_chat.
+  ///
+  /// In en, this message translates to:
+  /// **'Open group chat'**
+  String get events_open_chat;
+
   /// No description provided for @events_tab_favorites.
   ///
   /// In en, this message translates to:
@@ -481,6 +487,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'My favorites'**
   String get my_favorites;
+
+  /// No description provided for @chat_members_count.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} members'**
+  String chat_members_count(Object count);
+
+  /// No description provided for @chat_you_label.
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get chat_you_label;
+
+  /// No description provided for @chat_message_input_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Type a message'**
+  String get chat_message_input_hint;
+
+  /// No description provided for @chat_reply_count.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} replies'**
+  String chat_reply_count(Object count);
 
   /// No description provided for @no_events.
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -96,6 +96,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get event_title_field_label => 'Event Title';
 
   @override
+  String get events_open_chat => 'Open group chat';
+
+  @override
   String get events_tab_favorites => 'Liked';
 
   @override
@@ -205,6 +208,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get my_favorites => 'My favorites';
+
+  @override
+  String chat_members_count(Object count) {
+    return '$count members';
+  }
+
+  @override
+  String get chat_you_label => 'You';
+
+  @override
+  String get chat_message_input_hint => 'Type a message';
+
+  @override
+  String chat_reply_count(Object count) {
+    return '$count replies';
+  }
 
   @override
   String get no_events => 'No events yet';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -96,6 +96,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get event_title_field_label => '活动标题';
 
   @override
+  String get events_open_chat => '进入群聊';
+
+  @override
   String get events_tab_favorites => '我喜欢的';
 
   @override
@@ -201,6 +204,22 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get my_favorites => '我的收藏';
+
+  @override
+  String chat_members_count(Object count) {
+    return '$count 位成员';
+  }
+
+  @override
+  String get chat_you_label => '我';
+
+  @override
+  String get chat_message_input_hint => '发送一条消息…';
+
+  @override
+  String chat_reply_count(Object count) {
+    return '$count 条回复';
+  }
 
   @override
   String get no_events => '暂无活动';

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -29,6 +29,7 @@
   "event_participants_title": "Participants",
   "event_time_title": "Event time",
   "event_title_field_label": "Event Title",
+  "events_open_chat": "Open group chat",
   "events_tab_favorites": "Liked",
   "events_tab_registered": "Joined",
   "events_title": "Events",
@@ -70,6 +71,20 @@
   "max_interest_selection": "You can select up to 5 interest tags.",
   "my_events": "My events",
   "my_favorites": "My favorites",
+  "chat_members_count": "{count} members",
+  "@chat_members_count": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "chat_you_label": "You",
+  "chat_message_input_hint": "Type a message",
+  "chat_reply_count": "{count} replies",
+  "@chat_reply_count": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "no_events": "No events yet",
   "no_events_found": "No events found",
   "not_logged_in": "Not logged in",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -32,6 +32,7 @@
   "event_participants_title": "参与人数",
   "event_time_title": "活动时间",
   "event_title_field_label": "活动标题",
+  "events_open_chat": "进入群聊",
   "events_tab_favorites": "我喜欢的",
   "events_tab_registered": "我报名的",
   "events_title": "活动",
@@ -73,6 +74,20 @@
   "max_interest_selection": "最多只能选择 5 个兴趣标签喵~",
   "my_events": "我的活动",
   "my_favorites": "我的收藏",
+  "chat_members_count": "{count} 位成员",
+  "@chat_members_count": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "chat_you_label": "我",
+  "chat_message_input_hint": "发送一条消息…",
+  "chat_reply_count": "{count} 条回复",
+  "@chat_reply_count": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "no_events": "暂无活动",
   "no_events_found": "没有找到活动",
   "not_logged_in": "未登录",


### PR DESCRIPTION
## Summary
- add a new Teams-inspired `GroupChatPage` with participant carousel, message bubbles, attachments, and composer
- refresh the User Events page with chat-focused cards and navigation into the group chat experience
- extend localization files with strings needed for the chat UX in both English and Chinese

## Testing
- flutter gen-l10n *(fails: Flutter SDK is not available in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cd65018390832cbb3401c271c0988e