### PR TITLE
feat(events): poll events provider periodically

### DIFF
--- a/lib/core/state/event_map_state/events_providers.dart
+++ b/lib/core/state/event_map_state/events_providers.dart
@@ -1,4 +1,6 @@
 // lib/features/events/presentation/events_providers.dart
+import 'dart:async';
+
 import 'package:crew_app/core/state/di/providers.dart';
 import 'package:crew_app/features/events/data/event.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,13 +8,18 @@ import 'package:latlong2/latlong.dart';
 
 
 final eventsProvider =
-    AsyncNotifierProvider<EventsCtrl, List<Event>>(EventsCtrl.new);
+    AutoDisposeAsyncNotifierProvider<EventsCtrl, List<Event>>(EventsCtrl.new);
 
-class EventsCtrl extends AsyncNotifier<List<Event>> {
+class EventsCtrl extends AutoDisposeAsyncNotifier<List<Event>> {
+  Timer? _pollingTimer;
+
   @override
   Future<List<Event>> build() async {
     final api = ref.read(apiServiceProvider);
-    return api.getEvents();
+    final events = await api.getEvents();
+    state = AsyncData(events);
+    _startPolling();
+    return events;
   }
 
   Future<Event> createEvent({
@@ -25,9 +32,24 @@ class EventsCtrl extends AsyncNotifier<List<Event>> {
     final newEv = await api.createEvent(
       title, locationName, description, pos.latitude, pos.longitude,
     );
-    // 追加到列表
-    final curr = state.value ?? const <Event>[];
-    state = AsyncData([...curr, newEv]);
+    await _refreshEvents();
     return newEv;
+  }
+
+  void _startPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => unawaited(_refreshEvents()),
+    );
+    ref.onDispose(() {
+      _pollingTimer?.cancel();
+      _pollingTimer = null;
+    });
+  }
+
+  Future<void> _refreshEvents() async {
+    final api = ref.read(apiServiceProvider);
+    state = await AsyncValue.guard(() => api.getEvents());
   }
 }


### PR DESCRIPTION
## Summary
- convert `EventsCtrl` to an `AutoDisposeAsyncNotifier` that keeps a polling timer
- refresh the provider state on build, on a periodic timer, and after creating events
- cancel the polling timer when the provider is disposed to avoid background work

## Testing
- not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d068b4c4f4832cbff693c4f5f8ebfa