### PR TITLE
Add scroll activity aware navigation styling

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -137,117 +137,118 @@ class _AppState extends ConsumerState<App> {
     }
 
     final theme = Theme.of(context);
-    final navigationBarColor = _isScrolling
-        ? theme.colorScheme.surface.withOpacity(0.6)
-        : theme.colorScheme.surface;
-    final glassBorderColor = theme.colorScheme.outline.withOpacity(0.12);
-    final borderColor =
-        _isScrolling ? glassBorderColor : Colors.transparent;
+    final colorScheme = theme.colorScheme;
+    final borderRadius = const BorderRadius.only(
+      topLeft: Radius.circular(32),
+      topRight: Radius.circular(32),
+      bottomLeft: Radius.circular(40),
+      bottomRight: Radius.circular(40),
+    );
+    final glassBorderColor = colorScheme.outline.withOpacity(0.14);
+    final glassDecoration = BoxDecoration(
+      gradient: LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [
+          colorScheme.surface.withOpacity(0.65),
+          colorScheme.surfaceVariant.withOpacity(0.45),
+        ],
+      ),
+      borderRadius: borderRadius,
+      border: Border.all(color: glassBorderColor),
+      boxShadow: [
+        BoxShadow(
+          color: colorScheme.shadow.withOpacity(0.08),
+          blurRadius: 32,
+          offset: const Offset(0, 18),
+        ),
+      ],
+    );
+    final solidDecoration = BoxDecoration(
+      color: colorScheme.surface,
+      borderRadius: borderRadius,
+      boxShadow: [
+        BoxShadow(
+          color: colorScheme.shadow.withOpacity(0.12),
+          blurRadius: 24,
+          offset: const Offset(0, 12),
+        ),
+      ],
+    );
 
     return Scaffold(
       extendBody: true,
       body: IndexedStack(index: _index, children: _pages),
       bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.only(bottom: 32),
+        minimum: const EdgeInsets.only(bottom: 28),
         child: Align(
           alignment: Alignment.bottomCenter,
           child: FractionallySizedBox(
             widthFactor: 0.88,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(32),
-                  topRight: Radius.circular(32),
-                  bottomLeft: Radius.circular(40),
-                  bottomRight: Radius.circular(40),
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: theme.colorScheme.shadow.withOpacity(0.08),
-                    blurRadius: 24,
-                    offset: const Offset(0, 12),
+            child: ClipRRect(
+              borderRadius: borderRadius,
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 240),
+                  curve: Curves.easeInOut,
+                  decoration: _isScrolling ? glassDecoration : solidDecoration,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 10,
                   ),
-                ],
-              ),
-              child: ClipRRect(
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(32),
-                  topRight: Radius.circular(32),
-                  bottomLeft: Radius.circular(40),
-                  bottomRight: Radius.circular(40),
-                ),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 220),
-                    curve: Curves.easeInOut,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 18,
-                      vertical: 12,
-                    ),
-                    decoration: BoxDecoration(
-                      color: navigationBarColor,
-                      border: Border.all(color: borderColor),
-                      borderRadius: const BorderRadius.only(
-                        topLeft: Radius.circular(32),
-                        topRight: Radius.circular(32),
-                        bottomLeft: Radius.circular(40),
-                        bottomRight: Radius.circular(40),
-                      ),
-                    ),
-                    child: NavigationBarTheme(
-                      data: theme.navigationBarTheme.copyWith(
-                        backgroundColor: Colors.transparent,
-                        height: 64,
-                        indicatorColor: theme.colorScheme.primary,
-                        indicatorShape: const CircleBorder(),
-                        labelBehavior:
-                            NavigationDestinationLabelBehavior.alwaysShow,
-                        labelTextStyle: MaterialStateProperty.resolveWith(
-                          (states) => theme.textTheme.labelMedium?.copyWith(
-                            fontWeight: states.contains(MaterialState.selected)
-                                ? FontWeight.w600
-                                : FontWeight.w400,
-                            color: states.contains(MaterialState.selected)
-                                ? theme.colorScheme.onPrimary
-                                : theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                        iconTheme: MaterialStateProperty.resolveWith(
-                          (states) => IconThemeData(
-                            size: states.contains(MaterialState.selected)
-                                ? 30
-                                : 24,
-                            color: states.contains(MaterialState.selected)
-                                ? theme.colorScheme.onPrimary
-                                : theme.colorScheme.onSurfaceVariant,
-                          ),
+                  child: NavigationBarTheme(
+                    data: theme.navigationBarTheme.copyWith(
+                      backgroundColor: Colors.transparent,
+                      height: 64,
+                      indicatorColor: colorScheme.primary.withOpacity(0.18),
+                      indicatorShape: const StadiumBorder(),
+                      labelBehavior:
+                          NavigationDestinationLabelBehavior.alwaysShow,
+                      labelTextStyle: MaterialStateProperty.resolveWith(
+                        (states) => theme.textTheme.labelMedium?.copyWith(
+                          fontWeight: states.contains(MaterialState.selected)
+                              ? FontWeight.w600
+                              : FontWeight.w500,
+                          color: states.contains(MaterialState.selected)
+                              ? colorScheme.primary
+                              : colorScheme.onSurfaceVariant,
                         ),
                       ),
-                      child: NavigationBar(
-                        backgroundColor: Colors.transparent,
-                        elevation: 0,
-                        selectedIndex: _index,
-                        onDestinationSelected: (i) =>
-                            setState(() => _index = i),
-                        destinations: [
-                          NavigationDestination(
-                            icon: const Icon(Icons.event_outlined),
-                            selectedIcon: const Icon(Icons.event),
-                            label: loc.events,
-                          ),
-                          NavigationDestination(
-                            icon: const Icon(Icons.map_outlined),
-                            selectedIcon: const Icon(Icons.map),
-                            label: loc.map,
-                          ),
-                          const NavigationDestination(
-                            icon: Icon(Icons.chat_bubble_outline),
-                            selectedIcon: Icon(Icons.chat_bubble),
-                            label: 'Group',
-                          ),
-                        ],
+                      iconTheme: MaterialStateProperty.resolveWith(
+                        (states) => IconThemeData(
+                          size: states.contains(MaterialState.selected)
+                              ? 30
+                              : 26,
+                          color: states.contains(MaterialState.selected)
+                              ? colorScheme.primary
+                              : colorScheme.onSurfaceVariant,
+                        ),
                       ),
+                    ),
+                    child: NavigationBar(
+                      backgroundColor: Colors.transparent,
+                      elevation: 0,
+                      selectedIndex: _index,
+                      onDestinationSelected: (i) =>
+                          setState(() => _index = i),
+                      destinations: [
+                        NavigationDestination(
+                          icon: const Icon(Icons.event_outlined),
+                          selectedIcon: const Icon(Icons.event),
+                          label: loc.events,
+                        ),
+                        NavigationDestination(
+                          icon: const Icon(Icons.map_outlined),
+                          selectedIcon: const Icon(Icons.map),
+                          label: loc.map,
+                        ),
+                        const NavigationDestination(
+                          icon: Icon(Icons.chat_bubble_outline),
+                          selectedIcon: Icon(Icons.chat_bubble),
+                          label: 'Group',
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -139,26 +139,26 @@ class _AppState extends ConsumerState<App> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final borderRadius = const BorderRadius.only(
-      topLeft: Radius.circular(32),
-      topRight: Radius.circular(32),
-      bottomLeft: Radius.circular(40),
-      bottomRight: Radius.circular(40),
+      topLeft: Radius.circular(30),
+      topRight: Radius.circular(30),
+      bottomLeft: Radius.circular(30),
+      bottomRight: Radius.circular(30),
     );
-    final glassBorderColor = colorScheme.outline.withOpacity(0.14);
+    final glassBorderColor = colorScheme.outline.withValues(alpha:.14);
     final glassDecoration = BoxDecoration(
       gradient: LinearGradient(
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
         colors: [
-          colorScheme.surface.withOpacity(0.65),
-          colorScheme.surfaceVariant.withOpacity(0.45),
+          colorScheme.surface.withValues(alpha:0.65),
+          colorScheme.surfaceContainerHighest.withValues(alpha:0.45),
         ],
       ),
       borderRadius: borderRadius,
       border: Border.all(color: glassBorderColor),
       boxShadow: [
         BoxShadow(
-          color: colorScheme.shadow.withOpacity(0.08),
+          color: colorScheme.shadow.withValues(alpha:0.08),
           blurRadius: 32,
           offset: const Offset(0, 18),
         ),
@@ -169,7 +169,7 @@ class _AppState extends ConsumerState<App> {
       borderRadius: borderRadius,
       boxShadow: [
         BoxShadow(
-          color: colorScheme.shadow.withOpacity(0.12),
+          color: colorScheme.shadow.withValues(alpha:0.12),
           blurRadius: 24,
           offset: const Offset(0, 12),
         ),
@@ -201,26 +201,26 @@ class _AppState extends ConsumerState<App> {
                     data: theme.navigationBarTheme.copyWith(
                       backgroundColor: Colors.transparent,
                       height: 64,
-                      indicatorColor: colorScheme.primary.withOpacity(0.18),
+                      indicatorColor: colorScheme.primary.withValues(alpha:0.18),
                       indicatorShape: const StadiumBorder(),
                       labelBehavior:
                           NavigationDestinationLabelBehavior.alwaysShow,
-                      labelTextStyle: MaterialStateProperty.resolveWith(
+                      labelTextStyle: WidgetStateProperty.resolveWith(
                         (states) => theme.textTheme.labelMedium?.copyWith(
-                          fontWeight: states.contains(MaterialState.selected)
+                          fontWeight: states.contains(WidgetState.selected)
                               ? FontWeight.w600
                               : FontWeight.w500,
-                          color: states.contains(MaterialState.selected)
+                          color: states.contains(WidgetState.selected)
                               ? colorScheme.primary
                               : colorScheme.onSurfaceVariant,
                         ),
                       ),
-                      iconTheme: MaterialStateProperty.resolveWith(
+                      iconTheme: WidgetStateProperty.resolveWith(
                         (states) => IconThemeData(
-                          size: states.contains(MaterialState.selected)
+                          size: states.contains(WidgetState.selected)
                               ? 30
                               : 26,
-                          color: states.contains(MaterialState.selected)
+                          color: states.contains(WidgetState.selected)
                               ? colorScheme.primary
                               : colorScheme.onSurfaceVariant,
                         ),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:crew_app/core/state/legal/disclaimer_providers.dart';
 import 'package:crew_app/features/chat/user_event/prestantion/user_events_page.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:crew_app/shared/legal/disclaimer_dialog.dart';
+import 'package:crew_app/shared/widgets/scroll_activity_listener.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../features/events/presentation/list/events_list_page.dart';
 import '../features/events/presentation/map/events_map_page.dart';
 
@@ -50,9 +55,55 @@ class App extends ConsumerStatefulWidget {
 }
 
 class _AppState extends ConsumerState<App> {
-  int _index = 1;  // 默认打开“地图”
-  final _pages = const [EventsListPage(), EventsMapPage(), UserEventsPage()];
+  int _index = 1; // 默认打开“地图”
+  bool _isScrolling = false;
+  Timer? _scrollDebounceTimer;
+  late final List<Widget> _pages;
   int? _promptedVersion; // 防止同一版本重复弹
+
+  @override
+  void initState() {
+    super.initState();
+    _pages = [
+      ScrollActivityListener(
+        onScrollActivityChanged: _handleScrollActivity,
+        child: const EventsListPage(),
+      ),
+      ScrollActivityListener(
+        onScrollActivityChanged: _handleScrollActivity,
+        child: const EventsMapPage(),
+      ),
+      ScrollActivityListener(
+        onScrollActivityChanged: _handleScrollActivity,
+        child: const UserEventsPage(),
+      ),
+    ];
+  }
+
+  @override
+  void dispose() {
+    _scrollDebounceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handleScrollActivity(bool scrolling) {
+    _scrollDebounceTimer?.cancel();
+    if (scrolling) {
+      if (!_isScrolling) {
+        setState(() => _isScrolling = true);
+      }
+      return;
+    }
+
+    _scrollDebounceTimer = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) {
+        return;
+      }
+      if (_isScrolling) {
+        setState(() => _isScrolling = false);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -84,18 +135,70 @@ class _AppState extends ConsumerState<App> {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
+    final theme = Theme.of(context);
+    final navigationBarColor = _isScrolling
+        ? theme.colorScheme.surface.withOpacity(0.7)
+        : theme.colorScheme.surface;
+
     return Scaffold(
+      extendBody: true,
       body: IndexedStack(index: _index, children: _pages),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _index,
-        onDestinationSelected: (i) => setState(() => _index = i),
-        destinations: [
-          NavigationDestination(icon: const Icon(Icons.event), label: loc.events),
-          NavigationDestination(icon: const Icon(Icons.map), label: loc.map),
-          const NavigationDestination(icon: Icon(Icons.chat), label: 'Group'),
-        ],
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(24),
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: navigationBarColor,
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: NavigationBarTheme(
+                data: theme.navigationBarTheme.copyWith(
+                  indicatorColor: theme.colorScheme.primary.withOpacity(0.2),
+                  labelTextStyle: MaterialStateProperty.resolveWith(
+                    (states) => theme.textTheme.labelMedium?.copyWith(
+                      color: states.contains(MaterialState.selected)
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  iconTheme: MaterialStateProperty.resolveWith(
+                    (states) => IconThemeData(
+                      color: states.contains(MaterialState.selected)
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                child: NavigationBar(
+                  backgroundColor: Colors.transparent,
+                  selectedIndex: _index,
+                  onDestinationSelected: (i) => setState(() => _index = i),
+                  destinations: [
+                    NavigationDestination(
+                      icon: const Icon(Icons.event),
+                      label: loc.events,
+                    ),
+                    NavigationDestination(
+                      icon: const Icon(Icons.map),
+                      label: loc.map,
+                    ),
+                    const NavigationDestination(
+                      icon: Icon(Icons.chat),
+                      label: 'Group',
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
       ),
-      // extendBody: true,  // 是否延伸到 bottomNavigationBar 背后 适合做半透明效果，比如底部做玻璃罩
     );
   }
 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -71,6 +71,7 @@ class _AppState extends ConsumerState<App> {
       ),
       ScrollActivityListener(
         onScrollActivityChanged: _handleScrollActivity,
+        listenToPointerActivity: true,
         child: const EventsMapPage(),
       ),
       ScrollActivityListener(
@@ -137,62 +138,118 @@ class _AppState extends ConsumerState<App> {
 
     final theme = Theme.of(context);
     final navigationBarColor = _isScrolling
-        ? theme.colorScheme.surface.withOpacity(0.7)
+        ? theme.colorScheme.surface.withOpacity(0.6)
         : theme.colorScheme.surface;
+    final glassBorderColor = theme.colorScheme.outline.withOpacity(0.12);
+    final borderColor =
+        _isScrolling ? glassBorderColor : Colors.transparent;
 
     return Scaffold(
       extendBody: true,
       body: IndexedStack(index: _index, children: _pages),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(24),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 200),
-              curve: Curves.easeInOut,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.only(bottom: 32),
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: FractionallySizedBox(
+            widthFactor: 0.88,
+            child: DecoratedBox(
               decoration: BoxDecoration(
-                color: navigationBarColor,
-                borderRadius: BorderRadius.circular(24),
-              ),
-              child: NavigationBarTheme(
-                data: theme.navigationBarTheme.copyWith(
-                  indicatorColor: theme.colorScheme.primary.withOpacity(0.2),
-                  labelTextStyle: MaterialStateProperty.resolveWith(
-                    (states) => theme.textTheme.labelMedium?.copyWith(
-                      color: states.contains(MaterialState.selected)
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                  iconTheme: MaterialStateProperty.resolveWith(
-                    (states) => IconThemeData(
-                      color: states.contains(MaterialState.selected)
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(32),
+                  topRight: Radius.circular(32),
+                  bottomLeft: Radius.circular(40),
+                  bottomRight: Radius.circular(40),
                 ),
-                child: NavigationBar(
-                  backgroundColor: Colors.transparent,
-                  selectedIndex: _index,
-                  onDestinationSelected: (i) => setState(() => _index = i),
-                  destinations: [
-                    NavigationDestination(
-                      icon: const Icon(Icons.event),
-                      label: loc.events,
+                boxShadow: [
+                  BoxShadow(
+                    color: theme.colorScheme.shadow.withOpacity(0.08),
+                    blurRadius: 24,
+                    offset: const Offset(0, 12),
+                  ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(32),
+                  topRight: Radius.circular(32),
+                  bottomLeft: Radius.circular(40),
+                  bottomRight: Radius.circular(40),
+                ),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 220),
+                    curve: Curves.easeInOut,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 18,
+                      vertical: 12,
                     ),
-                    NavigationDestination(
-                      icon: const Icon(Icons.map),
-                      label: loc.map,
+                    decoration: BoxDecoration(
+                      color: navigationBarColor,
+                      border: Border.all(color: borderColor),
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(32),
+                        topRight: Radius.circular(32),
+                        bottomLeft: Radius.circular(40),
+                        bottomRight: Radius.circular(40),
+                      ),
                     ),
-                    const NavigationDestination(
-                      icon: Icon(Icons.chat),
-                      label: 'Group',
+                    child: NavigationBarTheme(
+                      data: theme.navigationBarTheme.copyWith(
+                        backgroundColor: Colors.transparent,
+                        height: 64,
+                        indicatorColor: theme.colorScheme.primary,
+                        indicatorShape: const CircleBorder(),
+                        labelBehavior:
+                            NavigationDestinationLabelBehavior.alwaysShow,
+                        labelTextStyle: MaterialStateProperty.resolveWith(
+                          (states) => theme.textTheme.labelMedium?.copyWith(
+                            fontWeight: states.contains(MaterialState.selected)
+                                ? FontWeight.w600
+                                : FontWeight.w400,
+                            color: states.contains(MaterialState.selected)
+                                ? theme.colorScheme.onPrimary
+                                : theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                        iconTheme: MaterialStateProperty.resolveWith(
+                          (states) => IconThemeData(
+                            size: states.contains(MaterialState.selected)
+                                ? 30
+                                : 24,
+                            color: states.contains(MaterialState.selected)
+                                ? theme.colorScheme.onPrimary
+                                : theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                      child: NavigationBar(
+                        backgroundColor: Colors.transparent,
+                        elevation: 0,
+                        selectedIndex: _index,
+                        onDestinationSelected: (i) =>
+                            setState(() => _index = i),
+                        destinations: [
+                          NavigationDestination(
+                            icon: const Icon(Icons.event_outlined),
+                            selectedIcon: const Icon(Icons.event),
+                            label: loc.events,
+                          ),
+                          NavigationDestination(
+                            icon: const Icon(Icons.map_outlined),
+                            selectedIcon: const Icon(Icons.map),
+                            label: loc.map,
+                          ),
+                          const NavigationDestination(
+                            icon: Icon(Icons.chat_bubble_outline),
+                            selectedIcon: Icon(Icons.chat_bubble),
+                            label: 'Group',
+                          ),
+                        ],
+                      ),
                     ),
-                  ],
+                  ),
                 ),
               ),
             ),

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -162,20 +161,25 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
           ],
         ),
       ),
-      floatingActionButtonLocation: const _AdaptiveEndFloatFabLocation(),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          final loc = ref.read(userLocationProvider).value;
-          if (loc != null) {
-            _map.move(loc, 14);
-            _map.rotate(0);
-          } else {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text("Unable to get location")),
-            );
-          }
-        },
-        child: const Icon(Icons.my_location),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButton: Padding(
+        padding: EdgeInsets.only(
+          bottom: 132 + MediaQuery.of(context).viewPadding.bottom,
+          right: 6,
+        ),
+        child: FloatingActionButton(
+          onPressed: () {
+            final loc = ref.read(userLocationProvider).value;
+            if (loc != null) {
+              _map.move(loc, 14);
+              _map.rotate(0);
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text("Unable to get location")));
+            }
+          },
+          child: const Icon(Icons.my_location),
+        ),
       ),
     );
   }
@@ -318,48 +322,4 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
       _currentSearchQuery = '';
     });
   }
-}
-
-class _AdaptiveEndFloatFabLocation extends FloatingActionButtonLocation {
-  const _AdaptiveEndFloatFabLocation();
-
-  @override
-  Offset getOffset(ScaffoldPrelayoutGeometry geometry) {
-    final fabSize = geometry.floatingActionButtonSize;
-    if (fabSize == null) {
-      return Offset.zero;
-    }
-
-    final double navTop = geometry.bottomNavigationBarTop ??
-        geometry.scaffoldSize.height;
-    final double availableHeight = math.min(
-      geometry.scaffoldSize.height - geometry.minInsets.bottom -
-          fabSize.height - kFloatingActionButtonMargin,
-      navTop - fabSize.height - kFloatingActionButtonMargin,
-    );
-
-    final double snackBarTop = geometry.snackBarSize == null
-        ? double.infinity
-        : geometry.scaffoldSize.height -
-            geometry.snackBarSize!.height -
-            fabSize.height -
-            kFloatingActionButtonMargin;
-
-    final double bottomSheetTop = geometry.bottomSheetSize == null
-        ? double.infinity
-        : geometry.scaffoldSize.height -
-            geometry.bottomSheetSize!.height -
-            fabSize.height -
-            kFloatingActionButtonMargin;
-
-    final double fabY = math.min(availableHeight, math.min(snackBarTop, bottomSheetTop));
-    final double fabX = geometry.scaffoldSize.width -
-        fabSize.width -
-        kFloatingActionButtonMargin;
-
-    return Offset(fabX, fabY);
-  }
-
-  @override
-  String toString() => 'AdaptiveEndFloatFabLocation';
 }

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -164,7 +164,8 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       floatingActionButton: Padding(
         padding: EdgeInsets.only(
-          bottom: 96 + MediaQuery.of(context).viewPadding.bottom,
+          bottom: 132 + MediaQuery.of(context).viewPadding.bottom,
+          right: 6,
         ),
         child: FloatingActionButton(
           onPressed: () {

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -161,18 +161,24 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          final loc = ref.read(userLocationProvider).value;
-          if (loc != null) {
-            _map.move(loc, 14);
-            _map.rotate(0);
-          } else {
-            ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text("Unable to get location")));
-          }
-        },
-        child: const Icon(Icons.my_location),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButton: Padding(
+        padding: EdgeInsets.only(
+          bottom: 96 + MediaQuery.of(context).viewPadding.bottom,
+        ),
+        child: FloatingActionButton(
+          onPressed: () {
+            final loc = ref.read(userLocationProvider).value;
+            if (loc != null) {
+              _map.move(loc, 14);
+              _map.rotate(0);
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text("Unable to get location")));
+            }
+          },
+          child: const Icon(Icons.my_location),
+        ),
       ),
     );
   }

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -161,25 +162,20 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
           ],
         ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-      floatingActionButton: Padding(
-        padding: EdgeInsets.only(
-          bottom: 132 + MediaQuery.of(context).viewPadding.bottom,
-          right: 6,
-        ),
-        child: FloatingActionButton(
-          onPressed: () {
-            final loc = ref.read(userLocationProvider).value;
-            if (loc != null) {
-              _map.move(loc, 14);
-              _map.rotate(0);
-            } else {
-              ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text("Unable to get location")));
-            }
-          },
-          child: const Icon(Icons.my_location),
-        ),
+      floatingActionButtonLocation: const _AdaptiveEndFloatFabLocation(),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          final loc = ref.read(userLocationProvider).value;
+          if (loc != null) {
+            _map.move(loc, 14);
+            _map.rotate(0);
+          } else {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text("Unable to get location")),
+            );
+          }
+        },
+        child: const Icon(Icons.my_location),
       ),
     );
   }
@@ -322,4 +318,48 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
       _currentSearchQuery = '';
     });
   }
+}
+
+class _AdaptiveEndFloatFabLocation extends FloatingActionButtonLocation {
+  const _AdaptiveEndFloatFabLocation();
+
+  @override
+  Offset getOffset(ScaffoldPrelayoutGeometry geometry) {
+    final fabSize = geometry.floatingActionButtonSize;
+    if (fabSize == null) {
+      return Offset.zero;
+    }
+
+    final double navTop = geometry.bottomNavigationBarTop ??
+        geometry.scaffoldSize.height;
+    final double availableHeight = math.min(
+      geometry.scaffoldSize.height - geometry.minInsets.bottom -
+          fabSize.height - kFloatingActionButtonMargin,
+      navTop - fabSize.height - kFloatingActionButtonMargin,
+    );
+
+    final double snackBarTop = geometry.snackBarSize == null
+        ? double.infinity
+        : geometry.scaffoldSize.height -
+            geometry.snackBarSize!.height -
+            fabSize.height -
+            kFloatingActionButtonMargin;
+
+    final double bottomSheetTop = geometry.bottomSheetSize == null
+        ? double.infinity
+        : geometry.scaffoldSize.height -
+            geometry.bottomSheetSize!.height -
+            fabSize.height -
+            kFloatingActionButtonMargin;
+
+    final double fabY = math.min(availableHeight, math.min(snackBarTop, bottomSheetTop));
+    final double fabX = geometry.scaffoldSize.width -
+        fabSize.width -
+        kFloatingActionButtonMargin;
+
+    return Offset(fabX, fabY);
+  }
+
+  @override
+  String toString() => 'AdaptiveEndFloatFabLocation';
 }

--- a/lib/shared/widgets/scroll_activity_listener.dart
+++ b/lib/shared/widgets/scroll_activity_listener.dart
@@ -2,30 +2,65 @@ import 'package:flutter/widgets.dart';
 
 typedef ScrollActivityChangedCallback = void Function(bool isScrolling);
 
-class ScrollActivityListener extends StatelessWidget {
+class ScrollActivityListener extends StatefulWidget {
   const ScrollActivityListener({
     super.key,
     required this.onScrollActivityChanged,
     required this.child,
+    this.listenToPointerActivity = false,
   });
 
   final ScrollActivityChangedCallback onScrollActivityChanged;
   final Widget child;
+  final bool listenToPointerActivity;
+
+  @override
+  State<ScrollActivityListener> createState() => _ScrollActivityListenerState();
+}
+
+class _ScrollActivityListenerState extends State<ScrollActivityListener> {
+  bool _pointerActive = false;
 
   bool _handleNotification(ScrollNotification notification) {
     if (notification is ScrollStartNotification) {
-      onScrollActivityChanged(true);
+      widget.onScrollActivityChanged(true);
     } else if (notification is ScrollEndNotification) {
-      onScrollActivityChanged(false);
+      widget.onScrollActivityChanged(false);
     }
     return false;
   }
 
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!widget.listenToPointerActivity) {
+      return;
+    }
+    _pointerActive = true;
+    widget.onScrollActivityChanged(true);
+  }
+
+  void _handlePointerEnd() {
+    if (!widget.listenToPointerActivity || !_pointerActive) {
+      return;
+    }
+    _pointerActive = false;
+    widget.onScrollActivityChanged(false);
+  }
+
   @override
   Widget build(BuildContext context) {
+    Widget result = widget.child;
+    if (widget.listenToPointerActivity) {
+      result = Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _handlePointerDown,
+        onPointerCancel: (_) => _handlePointerEnd(),
+        onPointerUp: (_) => _handlePointerEnd(),
+        child: result,
+      );
+    }
     return NotificationListener<ScrollNotification>(
       onNotification: _handleNotification,
-      child: child,
+      child: result,
     );
   }
 }

--- a/lib/shared/widgets/scroll_activity_listener.dart
+++ b/lib/shared/widgets/scroll_activity_listener.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+
+typedef ScrollActivityChangedCallback = void Function(bool isScrolling);
+
+class ScrollActivityListener extends StatelessWidget {
+  const ScrollActivityListener({
+    super.key,
+    required this.onScrollActivityChanged,
+    required this.child,
+  });
+
+  final ScrollActivityChangedCallback onScrollActivityChanged;
+  final Widget child;
+
+  bool _handleNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) {
+      onScrollActivityChanged(true);
+    } else if (notification is ScrollEndNotification) {
+      onScrollActivityChanged(false);
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleNotification,
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `ScrollActivityListener` to observe scroll start and end events
- track scroll activity in `App` to toggle a glassmorphism effect on the bottom navigation bar
- restyle the navigation bar with animated glass and solid states while extending the scaffold body

## Testing
- dart format lib/app/app.dart lib/shared/widgets/scroll_activity_listener.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d834ad2890832ca15c1d0258836390