### PR TITLE
Handle feedback dismissal

### DIFF
--- a/lib/features/settings/presentation/settings/settings_page.dart
+++ b/lib/features/settings/presentation/settings/settings_page.dart
@@ -118,11 +118,12 @@ class SettingsPage extends ConsumerWidget {
                   if (!context.mounted) {
                     return;
                   }
-                  if (submitted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(loc.feedback_thanks)),
-                    );
+                  if (submitted != true) {
+                    return;
                   }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(loc.feedback_thanks)),
+                  );
                 },
               ),
               ListTile(


### PR DESCRIPTION
## Summary
- update the feedback service to await `showAndGetUserFeedback`, returning `false` when the overlay is dismissed
- keep logging and Crashlytics reporting for successful feedback submissions
- guard the settings feedback handler so it exits early when no submission occurs

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd81d70f04832c88866fc78195efd2