### PR TITLE
Fix API service paths to respect base URL

### DIFF
--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -20,7 +20,7 @@ class ApiService {
 
   Future<List<Event>> getEvents() async {
     try {
-      final response = await _dio.get("/events");
+      final response = await _dio.get("events");
       if (response.statusCode == 200) {
         return (response.data as List)
             .map((e) => Event.fromJson(e))
@@ -38,7 +38,7 @@ class ApiService {
   Future<Event> createEvent(String title, String location, String description,
       double lat, double lng) async {
     try {
-      final response = await _dio.post("/events", data: {
+      final response = await _dio.post("events", data: {
         "title": title,
         "location": location,
         "description": description,
@@ -60,7 +60,7 @@ class ApiService {
   Future<List<Event>> searchEvents(String query) async {
     try {
       final response = await _dio.get(
-        "/events/search",
+        "events/search",
         queryParameters: {"query": query},
       );
 

--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:crew_app/core/network/api_service.dart';
+import 'package:crew_app/core/config/environment.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ApiService requests include /api segment in URL', () async {
+    final capturedUrls = <String>[];
+    final dio = Dio(BaseOptions(baseUrl: Env.current));
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          capturedUrls.add(options.uri.toString());
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              statusCode: 200,
+              data: [],
+            ),
+          );
+        },
+      ),
+    );
+
+    final apiService = ApiService(dio: dio);
+
+    await apiService.getEvents();
+
+    expect(capturedUrls, isNotEmpty);
+    expect(capturedUrls.single, contains('/api/events'));
+  });
+}


### PR DESCRIPTION
## Summary
- remove the leading slash from event endpoints so Dio appends them to Env.current's /api base URL
- add a unit test that asserts ApiService requests resolve to URLs containing the /api segment

## Testing
- dart test test/api_service_test.dart *(fails: `dart` command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd81e442f8832c8776b15336e31498