### PR TITLE
Refactor auth consumers to use Riverpod providers

### DIFF
--- a/lib/features/events/presentation/map/widgets/avatar_icon.dart
+++ b/lib/features/events/presentation/map/widgets/avatar_icon.dart
@@ -1,53 +1,32 @@
 // widgets/avatar_icon.dart
 import 'dart:io';
-import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart' as fa;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/state/avatar/avatar_provider.dart';
+import '../../../../../core/state/auth/auth_providers.dart';
 
-class AvatarIcon extends ConsumerStatefulWidget  {
+class AvatarIcon extends ConsumerWidget {
   final void Function(bool authed) onTap;
   const AvatarIcon({super.key, required this.onTap});
 
   @override
-  ConsumerState<AvatarIcon> createState() => _AvatarIconState();
-}
-
-class _AvatarIconState extends ConsumerState<AvatarIcon> {
-  fa.User? _user;
-  StreamSubscription<fa.User?>? _authSub;
-
-  @override
-  void initState() {
-    super.initState();
-    // 监听用户状态变化
-    _user = fa.FirebaseAuth.instance.currentUser;
-    _authSub = fa.FirebaseAuth.instance.authStateChanges().listen((u) {
-      if (mounted) setState(() => _user = u);
-    });
-  }
-
-  @override
-  void dispose() {
-    _authSub?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final customPath = ref.watch(avatarProvider);
+    final authState = ref.watch(authStateProvider);
+    final fa.User? user = authState.value ?? ref.watch(currentUserProvider);
+
     ImageProvider? img;
-    if (customPath != null && _user != null) {
+    if (customPath != null && user != null) {
       img = FileImage(File(customPath));
-    } else if ((_user?.photoURL?.isNotEmpty ?? false)) {
-      img = NetworkImage(_user!.photoURL!);
+    } else if ((user?.photoURL?.isNotEmpty ?? false)) {
+      img = NetworkImage(user!.photoURL!);
     }
 
     return InkResponse(
       radius: 22,
-      onTap: () => widget.onTap(_user != null),
+      onTap: () => onTap(user != null),
       child: CircleAvatar(
         radius: 16,
         foregroundImage: img,

--- a/lib/features/profile/presentation/profile/profile_page.dart
+++ b/lib/features/profile/presentation/profile/profile_page.dart
@@ -1,59 +1,31 @@
 import 'dart:io';
-import 'dart:async';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fa;
 import 'package:image_picker/image_picker.dart';
+import '../../../../core/state/auth/auth_providers.dart';
 import '../../../../core/state/avatar/avatar_provider.dart';
 
-class ProfilePage extends ConsumerStatefulWidget {
+class ProfilePage extends ConsumerWidget {
   const ProfilePage({super.key});
 
-  @override
-  ConsumerState<ProfilePage> createState() => _ProfilePageState();
-}
-
-class _ProfilePageState extends ConsumerState<ProfilePage> {
-  fa.User? _user;
-  StreamSubscription<fa.User?>? _authSub;
-
-  @override
-  void initState() {
-    super.initState();
-    _user = fa.FirebaseAuth.instance.currentUser;
-    // 监听用户状态变化
-    _authSub = fa.FirebaseAuth.instance.authStateChanges().listen((user) {
-      if (mounted) {
-        setState(() {
-          _user = user;
-        });
-      }
-    });
+  Future<void> _signOut(BuildContext context, WidgetRef ref) async {
+    await ref.read(signOutProvider)();
+    if (!context.mounted) return;
+    final loc = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.logout_success)),
+    );
   }
 
   @override
-  void dispose() {
-    _authSub?.cancel();
-    super.dispose();
-  }
-
-  Future<void> _signOut() async {
-    await fa.FirebaseAuth.instance.signOut();
-    if (!mounted) return;
-    if (context.mounted) {
-      final loc = AppLocalizations.of(context)!;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(loc.logout_success)),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final loc = AppLocalizations.of(context)!;
+    final authState = ref.watch(authStateProvider);
+    final user = authState.value ?? ref.watch(currentUserProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -69,7 +41,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _ProfileHeader(user: _user),
+          const _ProfileHeader(),
           const SizedBox(height: 16),
           Card(
             child: Column(
@@ -114,7 +86,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
             mainAxisSize: MainAxisSize.min,
             children: [
               // 只有登录状态下显示退出按钮
-              if (_user != null)
+              if (user != null)
                 SizedBox(
                   width: double.infinity,
                   child: FilledButton(
@@ -122,11 +94,11 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
                       backgroundColor: theme.colorScheme.error,
                       foregroundColor: theme.colorScheme.onError,
                     ),
-                    onPressed: _signOut,
+                    onPressed: () => _signOut(context, ref),
                     child: Text(loc.action_logout),
                   ),
                 ),
-              if (_user != null) const SizedBox(height: 16),
+              if (user != null) const SizedBox(height: 16),
               Text(
                 loc.version_label('1.0.0'),
                 textAlign: TextAlign.center,
@@ -143,13 +115,14 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
 }
 
 class _ProfileHeader extends ConsumerWidget {
-  final fa.User? user;
-  const _ProfileHeader({this.user});
+  const _ProfileHeader();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final loc = AppLocalizations.of(context)!;
+    final authState = ref.watch(authStateProvider);
+    final user = authState.value ?? ref.watch(currentUserProvider);
 
     if (user == null) {
       return Card(
@@ -190,15 +163,15 @@ class _ProfileHeader extends ConsumerWidget {
         child: Row(
           children: [
             GestureDetector(
-              onTap: () => _onAvatarTap(context, ref),
+              onTap: () => _onAvatarTap(context, ref, user),
               child: CircleAvatar(
                 radius: 32,
                 foregroundImage: customPath != null
                     ? FileImage(File(customPath))
-                    : (user!.photoURL != null
-                        ? NetworkImage(user!.photoURL!)
+                    : (user.photoURL != null
+                        ? NetworkImage(user.photoURL!)
                         : null),
-                child: (customPath == null && user!.photoURL == null)
+                child: (customPath == null && user.photoURL == null)
                     ? const Icon(Icons.person, size: 32)
                     : null,
               ),
@@ -208,10 +181,10 @@ class _ProfileHeader extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(user!.displayName ?? loc.user_display_name_fallback,
+                  Text(user.displayName ?? loc.user_display_name_fallback,
                       style: theme.textTheme.titleMedium),
                   const SizedBox(height: 4),
-                  Text(user!.email ?? loc.email_unbound,
+                  Text(user.email ?? loc.email_unbound,
                       style: theme.textTheme.bodySmall),
                 ],
               ),
@@ -222,7 +195,8 @@ class _ProfileHeader extends ConsumerWidget {
     );
   }
 
-  Future<void> _onAvatarTap(BuildContext context, WidgetRef ref) async {
+  Future<void> _onAvatarTap(
+      BuildContext context, WidgetRef ref, fa.User? user) async {
     if (user == null) return;
     final loc = AppLocalizations.of(context)!;
     final action = await showModalBottomSheet<String>(


### PR DESCRIPTION
## Summary
- replace manual FirebaseAuth listeners on the profile page with Riverpod auth providers
- update the profile header to rebuild from provider state instead of constructor data
- refactor the map avatar icon to derive the signed-in user via shared providers

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd81df7db0832c8a8f845d66268f6c