### PR TITLE
Add share bottom sheet to event detail page

### DIFF
--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -620,6 +620,54 @@ abstract class AppLocalizations {
   /// **'Registration open'**
   String get registration_open;
 
+  /// No description provided for @share_event_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Share event'**
+  String get share_event_title;
+
+  /// No description provided for @share_option_system.
+  ///
+  /// In en, this message translates to:
+  /// **'Share via system'**
+  String get share_option_system;
+
+  /// No description provided for @share_option_wechat.
+  ///
+  /// In en, this message translates to:
+  /// **'WeChat'**
+  String get share_option_wechat;
+
+  /// No description provided for @share_option_whatsapp.
+  ///
+  /// In en, this message translates to:
+  /// **'WhatsApp'**
+  String get share_option_whatsapp;
+
+  /// No description provided for @share_option_copy_link.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy link'**
+  String get share_option_copy_link;
+
+  /// No description provided for @share_copy_success.
+  ///
+  /// In en, this message translates to:
+  /// **'Link copied to clipboard'**
+  String get share_copy_success;
+
+  /// No description provided for @share_app_not_installed.
+  ///
+  /// In en, this message translates to:
+  /// **'{appName} is not installed on this device.'**
+  String share_app_not_installed({required Object appName});
+
+  /// No description provided for @share_event_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Check out "{eventTitle}" on Crew: {shareUrl}'**
+  String share_event_message({required Object eventTitle, required Object shareUrl});
+
   /// No description provided for @school_label_optional.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -286,6 +286,34 @@ class AppLocalizationsEn extends AppLocalizations {
   String get registration_open => 'Registration open';
 
   @override
+  String get share_event_title => 'Share event';
+
+  @override
+  String get share_option_system => 'Share via system';
+
+  @override
+  String get share_option_wechat => 'WeChat';
+
+  @override
+  String get share_option_whatsapp => 'WhatsApp';
+
+  @override
+  String get share_option_copy_link => 'Copy link';
+
+  @override
+  String get share_copy_success => 'Link copied to clipboard';
+
+  @override
+  String share_app_not_installed({required Object appName}) {
+    return '$appName is not installed on this device.';
+  }
+
+  @override
+  String share_event_message({required Object eventTitle, required Object shareUrl}) {
+    return 'Check out "${eventTitle}" on Crew: ${shareUrl}';
+  }
+
+  @override
   String get school_label_optional => 'School (optional)';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -280,6 +280,34 @@ class AppLocalizationsZh extends AppLocalizations {
   String get registration_open => '正在报名中';
 
   @override
+  String get share_event_title => '分享活动';
+
+  @override
+  String get share_option_system => '系统分享';
+
+  @override
+  String get share_option_wechat => '微信';
+
+  @override
+  String get share_option_whatsapp => 'WhatsApp';
+
+  @override
+  String get share_option_copy_link => '复制链接';
+
+  @override
+  String get share_copy_success => '链接已复制到剪贴板';
+
+  @override
+  String share_app_not_installed({required Object appName}) {
+    return '未检测到 ${appName}，请先安装应用';
+  }
+
+  @override
+  String share_event_message({required Object eventTitle, required Object shareUrl}) {
+    return '快来看看「${eventTitle}」：${shareUrl}';
+  }
+
+  @override
   String get school_label_optional => '学校（选填）';
 
   @override

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -113,6 +113,25 @@
   "profile_title": "Profile",
   "registration_not_implemented": "Registration feature is not available yet.",
   "registration_open": "Registration open",
+  "share_event_title": "Share event",
+  "share_option_system": "Share via system",
+  "share_option_wechat": "WeChat",
+  "share_option_whatsapp": "WhatsApp",
+  "share_option_copy_link": "Copy link",
+  "share_copy_success": "Link copied to clipboard",
+  "share_app_not_installed": "{appName} is not installed on this device.",
+  "@share_app_not_installed": {
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "share_event_message": "Check out \"{eventTitle}\" on Crew: {shareUrl}",
+  "@share_event_message": {
+    "placeholders": {
+      "eventTitle": {},
+      "shareUrl": {}
+    }
+  },
   "school_label_optional": "School (optional)",
   "search_hint": "Search events",
   "search_tags_hint": "Search tags...",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -155,6 +155,25 @@
   "profile_title": "个人中心",
   "registration_not_implemented": "报名功能尚未实现",
   "registration_open": "正在报名中",
+  "share_event_title": "分享活动",
+  "share_option_system": "系统分享",
+  "share_option_wechat": "微信",
+  "share_option_whatsapp": "WhatsApp",
+  "share_option_copy_link": "复制链接",
+  "share_copy_success": "链接已复制到剪贴板",
+  "share_app_not_installed": "未检测到 {appName}，请先安装应用",
+  "@share_app_not_installed": {
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "share_event_message": "快来看看「{eventTitle}」：{shareUrl}",
+  "@share_event_message": {
+    "placeholders": {
+      "eventTitle": {},
+      "shareUrl": {}
+    }
+  },
   "school_label_optional": "学校（选填）",
   "search_hint": "搜索活动",
   "search_tags_hint": "搜索标签...",


### PR DESCRIPTION
## Summary
- add a share bottom sheet to the event detail page with system, WeChat, WhatsApp, and copy link actions
- wire up share_plus, url_launcher, and clipboard handling to drive each share action
- localize the new share labels and messages in both English and Chinese

## Testing
- unable to run flutter tooling in the current environment

------
https://chatgpt.com/codex/tasks/task_e_68ded8409858832ca6d62f4c8f39e2ea