### PR TITLE
Add event metadata to share card and normalize event data

### DIFF
--- a/lib/features/events/data/event.dart
+++ b/lib/features/events/data/event.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 class Event {
   final int id;
   final String title;
@@ -7,6 +9,12 @@ class Event {
   final double longitude;
   final List<String> imageUrls;
   final String coverImageUrl;
+  final DateTime? startTime;
+  final DateTime? endTime;
+  final int? currentParticipants;
+  final int? maxParticipants;
+  final String? timeText;
+  final String? participantsText;
 
   Event({
     required this.id,
@@ -17,9 +25,45 @@ class Event {
     required this.longitude,
     required this.imageUrls,
     required this.coverImageUrl,
+    this.startTime,
+    this.endTime,
+    this.currentParticipants,
+    this.maxParticipants,
+    this.timeText,
+    this.participantsText,
   });
 
   factory Event.fromJson(Map<String, dynamic> json) {
+    DateTime? parseDate(dynamic value) {
+      if (value == null) return null;
+      if (value is DateTime) return value;
+      if (value is int) {
+        // Support seconds and milliseconds since epoch.
+        if (value < 1000000000000) {
+          return DateTime.fromMillisecondsSinceEpoch(value * 1000);
+        }
+        return DateTime.fromMillisecondsSinceEpoch(value);
+      }
+      if (value is double) {
+        final milliseconds = value > 1000000000000
+            ? value.toInt()
+            : (value * 1000).toInt();
+        return DateTime.fromMillisecondsSinceEpoch(milliseconds);
+      }
+      if (value is String && value.isNotEmpty) {
+        return DateTime.tryParse(value);
+      }
+      return null;
+    }
+
+    int? parseInt(dynamic value) {
+      if (value == null) return null;
+      if (value is int) return value;
+      if (value is double) return value.toInt();
+      if (value is String) return int.tryParse(value);
+      return null;
+    }
+
     return Event(
       id: json['id'] as int,
       title: json['title'] as String,
@@ -31,6 +75,63 @@ class Event {
           .map((e) => e.toString())
           .toList(),
       coverImageUrl: json['coverImageUrl'] as String? ?? '',
+      startTime: parseDate(json['startTime'] ?? json['start_time']),
+      endTime: parseDate(json['endTime'] ?? json['end_time']),
+      currentParticipants:
+          parseInt(json['currentParticipants'] ?? json['current_participants']),
+      maxParticipants:
+          parseInt(json['maxParticipants'] ?? json['max_participants']),
+      timeText: (json['timeText'] ?? json['time_text']) as String?,
+      participantsText:
+          (json['participantsText'] ?? json['participants_text']) as String?,
     );
+  }
+
+  /// Returns the preferred image url for the event, falling back to the cover image.
+  String get primaryImageUrl {
+    if (imageUrls.isNotEmpty && imageUrls.first.isNotEmpty) {
+      return imageUrls.first;
+    }
+    return coverImageUrl;
+  }
+
+  /// Returns a formatted start time string respecting the provided locale, if available.
+  String? formattedStartTime(String locale) {
+    final customText = timeText?.trim();
+    if (customText != null && customText.isNotEmpty) {
+      return customText;
+    }
+
+    final start = startTime;
+    if (start == null) return null;
+
+    final dateFormat = DateFormat.yMMMd(locale);
+    final timeFormat = DateFormat.Hm(locale);
+    return '${dateFormat.format(start)} ${timeFormat.format(start)}';
+  }
+
+  /// Returns a formatted participants string, if enough data is present.
+  String? get participantsDisplayText {
+    final customText = participantsText?.trim();
+    if (customText != null && customText.isNotEmpty) {
+      return customText;
+    }
+
+    final current = currentParticipants;
+    final max = maxParticipants;
+
+    if (current != null && max != null) {
+      return '$current/$max';
+    }
+
+    if (current != null) {
+      return '$current';
+    }
+
+    if (max != null) {
+      return '$max';
+    }
+
+    return null;
   }
 }

--- a/lib/features/events/presentation/detail/widgets/event_info_card.dart
+++ b/lib/features/events/presentation/detail/widgets/event_info_card.dart
@@ -33,8 +33,16 @@ class EventInfoCard extends StatelessWidget {
             ),
             const Divider(height: 20),
             const SizedBox(height: 12),
-            _detailRow(Icons.calendar_today, loc.event_time_title, loc.to_be_announced),
-            _detailRow(Icons.people, loc.event_participants_title, loc.to_be_announced),
+            _detailRow(
+              Icons.calendar_today,
+              loc.event_time_title,
+              event.formattedStartTime(loc.localeName) ?? loc.to_be_announced,
+            ),
+            _detailRow(
+              Icons.people,
+              loc.event_participants_title,
+              event.participantsDisplayText ?? loc.to_be_announced,
+            ),
             InkWell(
               onTap: onTapLocation,
               child: _detailRow(

--- a/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
+++ b/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
@@ -93,6 +93,10 @@ class SharePreviewCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final timeText = event.formattedStartTime(loc.localeName);
+    final participantsText = event.participantsDisplayText;
+    final showDetails =
+        (timeText?.isNotEmpty ?? false) || (participantsText?.isNotEmpty ?? false);
     return RepaintBoundary(
       key: previewKey,
       child: Container(
@@ -121,10 +125,7 @@ class SharePreviewCard extends StatelessWidget {
                 children: [
                   AspectRatio(
                     aspectRatio: 16 / 9,
-                    child: Image(
-                      image: CachedNetworkImageProvider(event.coverImageUrl),
-                      fit: BoxFit.cover,
-                    ),
+                    child: _SharePreviewImage(imageUrl: event.primaryImageUrl),
                   ),
                   Positioned.fill(
                     child: DecoratedBox(
@@ -226,7 +227,15 @@ class SharePreviewCard extends StatelessWidget {
                       height: 1.4,
                     ),
                   ),
-                  const SizedBox(height: 18),
+                  if (showDetails) ...[
+                    const SizedBox(height: 18),
+                    _ShareEventDetails(
+                      timeText: timeText,
+                      participantsText: participantsText,
+                      loc: loc,
+                    ),
+                    const SizedBox(height: 18),
+                  ],
                   Container(
                     padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
                     decoration: BoxDecoration(
@@ -333,6 +342,114 @@ class ShareActionButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _SharePreviewImage extends StatelessWidget {
+  final String imageUrl;
+
+  const _SharePreviewImage({required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    if (imageUrl.isEmpty) {
+      return Container(
+        color: Colors.grey.shade300,
+        child: const Center(
+          child: Icon(Icons.image_not_supported_outlined, color: Colors.white70, size: 48),
+        ),
+      );
+    }
+
+    return CachedNetworkImage(
+      imageUrl: imageUrl,
+      fit: BoxFit.cover,
+      placeholder: (_, __) => const Center(child: CircularProgressIndicator()),
+      errorWidget: (_, __, ___) => Container(
+        color: Colors.grey.shade300,
+        child: const Center(
+          child: Icon(Icons.broken_image_outlined, color: Colors.white70, size: 48),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShareEventDetails extends StatelessWidget {
+  final String? timeText;
+  final String? participantsText;
+  final AppLocalizations loc;
+
+  const _ShareEventDetails({
+    required this.timeText,
+    required this.participantsText,
+    required this.loc,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final details = <Widget>[];
+    final timeValue = timeText;
+    final participantsValue = participantsText;
+
+    if (timeValue != null && timeValue.isNotEmpty) {
+      details.add(_detailRow(Icons.calendar_today_rounded, loc.event_time_title, timeValue));
+    }
+
+    if (participantsValue != null && participantsValue.isNotEmpty) {
+      if (details.isNotEmpty) {
+        details.add(const SizedBox(height: 12));
+      }
+      details.add(_detailRow(Icons.people_alt_rounded, loc.event_participants_title, participantsValue));
+    }
+
+    if (details.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF5E8),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: details,
+      ),
+    );
+  }
+
+  Widget _detailRow(IconData icon, String title, String value) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: Colors.orange.shade700),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(fontSize: 12, color: Colors.black54),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                value,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.black87,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/events/presentation/map/sheets/event_bottom_sheet.dart
+++ b/lib/features/events/presentation/map/sheets/event_bottom_sheet.dart
@@ -13,9 +13,7 @@ void showEventBottomSheet({
 }) {
   // Tips： 判断imageUrls是否有值，否则用coverImageUrl
   // (这是当前后端的问题，因为目前后端只有在创建的时候才会自动赋值coverImageUrl，而用SeedDataService预先插入的数据没用自动首页逻辑)，日后待看获取直接用event.coverImageUrl
-  final imageUrl = (event.imageUrls.isNotEmpty)
-      ? event.imageUrls.first
-      : event.coverImageUrl;
+  final imageUrl = event.primaryImageUrl;
   final loc = AppLocalizations.of(context)!;
 
   showModalBottomSheet(
@@ -131,16 +129,20 @@ void showEventBottomSheet({
                                 const Icon(Icons.groups,
                                     size: 16, color: Colors.grey),
                                 const SizedBox(width: 2),
-                                const Text(/*ev.peopleText ?? */ '3-5人',
-                                    style: TextStyle(color: Colors.black54)),
+                                Text(
+                                    event.participantsDisplayText ??
+                                        loc.to_be_announced,
+                                    style: const TextStyle(color: Colors.black54)),
                               ]),
                               const SizedBox(height: 6),
                               Row(children: [
                                 const Icon(Icons.event,
                                     size: 16, color: Colors.grey),
                                 const SizedBox(width: 4),
-                                const Text(/*ev.timeText ??*/ '12.28 8:00',
-                                    style: TextStyle(color: Colors.black87)),
+                                Text(
+                                    event.formattedStartTime(loc.localeName) ??
+                                        loc.to_be_announced,
+                                    style: const TextStyle(color: Colors.black87)),
                                 const Spacer(),
                                 SizedBox(
                                   height: 36,


### PR DESCRIPTION
## Summary
- extend the event model to parse scheduling and participant metadata and expose formatted helpers
- enhance the share preview card to display time and participant details with a robust image fallback
- reuse the new metadata across the event info card and map bottom sheet for consistent displays

## Testing
- Not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0151f5e18832ca9c4a30480bb1db3