### PR TITLE
Add copy shortcut to share sheet preview card

### DIFF
--- a/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
+++ b/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
@@ -40,6 +40,7 @@ class EventShareSheet extends StatelessWidget {
                 loc: loc,
                 previewKey: previewKey,
                 shareLink: shareLink,
+                onCopyLink: onCopyLink,
               ),
               const SizedBox(height: 20),
               Text(
@@ -81,6 +82,7 @@ class SharePreviewCard extends StatelessWidget {
   final AppLocalizations loc;
   final GlobalKey previewKey;
   final String shareLink;
+  final Future<void> Function() onCopyLink;
 
   const SharePreviewCard({
     super.key,
@@ -88,6 +90,7 @@ class SharePreviewCard extends StatelessWidget {
     required this.loc,
     required this.previewKey,
     required this.shareLink,
+    required this.onCopyLink,
   });
 
   @override
@@ -271,6 +274,21 @@ class SharePreviewCard extends StatelessWidget {
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ],
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(12),
+                            onTap: () => onCopyLink(),
+                            child: Padding(
+                              padding: const EdgeInsets.all(8),
+                              child: Icon(
+                                Icons.copy_rounded,
+                                color: Colors.orange.shade700,
+                              ),
+                            ),
                           ),
                         ),
                         const SizedBox(width: 16),


### PR DESCRIPTION
## Summary
- pass the copy-link callback into the share preview card
- add a copy icon next to the event link so it can be copied directly from the preview

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e04a972100832c9cc4ca136ed2cfb2