### PR TITLE
Update Chinese share save label

### DIFF
--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -292,7 +292,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get share_action_copy_link => '复制链接';
 
   @override
-  String get share_action_save_image => '保存图片';
+  String get share_action_save_image => '保存活动';
 
   @override
   String get share_action_share_system => '系统分享';

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -159,7 +159,7 @@
   "share_card_subtitle": "把这个活动卡片分享给好友吧",
   "share_card_qr_caption": "扫描二维码查看活动详情",
   "share_action_copy_link": "复制链接",
-  "share_action_save_image": "保存图片",
+  "share_action_save_image": "保存活动",
   "share_action_share_system": "系统分享",
   "share_copy_success": "活动链接已复制",
   "share_save_success": "分享卡片已保存到相册",


### PR DESCRIPTION
## Summary
- update the Chinese localization to label the share card save action as "保存活动"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e055337490832c8fe4272a8071858e