### PR TITLE
Localize group navigation destination label

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -112,10 +112,10 @@ class _AppState extends ConsumerState<App> {
         selectedIcon: const Icon(Icons.map),
         label: loc.map,
       ),
-      const NavigationDestination(
-        icon: Icon(Icons.chat_bubble_outline),
-        selectedIcon: Icon(Icons.chat_bubble),
-        label: 'Group',
+      NavigationDestination(
+        icon: const Icon(Icons.chat_bubble_outline),
+        selectedIcon: const Icon(Icons.chat_bubble),
+        label: loc.group,
       ),
     ];
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -524,6 +524,12 @@ abstract class AppLocalizations {
   /// **'Map'**
   String get map;
 
+  /// No description provided for @group.
+  ///
+  /// In en, this message translates to:
+  /// **'Group'**
+  String get group;
+
   /// No description provided for @max_interest_selection.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -233,6 +233,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get map => 'Map';
 
   @override
+  String get group => 'Group';
+
+  @override
   String get max_interest_selection => 'You can select up to 5 interest tags.';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -228,6 +228,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get map => '地图';
 
   @override
+  String get group => '群聊';
+
+  @override
   String get max_interest_selection => '最多只能选择 5 个兴趣标签喵~';
 
   @override

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -87,6 +87,7 @@
   "login_title": "Welcome to Crew",
   "logout_success": "Signed out successfully.",
   "map": "Map",
+  "group": "Group",
   "max_interest_selection": "You can select up to 5 interest tags.",
   "my_events": "My events",
   "my_favorites": "My favorites",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -129,6 +129,7 @@
   "login_title": "欢迎来到 Crew",
   "logout_success": "已退出登录",
   "map": "地图",
+  "group": "群聊",
   "max_interest_selection": "最多只能选择 5 个兴趣标签喵~",
   "my_events": "我的活动",
   "my_favorites": "我的收藏",


### PR DESCRIPTION
## Summary
- add localized strings for the group navigation destination in English and Chinese
- update the bottom navigation to use the localized label

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e141651bd4832cb2aea2b9c768f469