### PR TITLE
Integrate Crew API authenticated user sync

### DIFF
--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -1,79 +1,150 @@
 import 'package:crew_app/core/config/environment.dart';
 import 'package:dio/dio.dart';
-import '../error/api_exception.dart';
+
 import '../../features/events/data/event.dart';
+import '../../features/user/data/authenticated_user_dto.dart';
+import '../error/api_exception.dart';
+import 'auth/auth_service.dart';
 
 class ApiService {
-  late final Dio _dio;
+  ApiService({
+    Dio? dio,
+    required AuthService authService,
+  })  : _dio = dio ?? Dio(BaseOptions(baseUrl: Env.current)),
+        _auth = authService {
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final headers = await _auth.authHeader();
+          options.headers.addAll(headers);
+          handler.next(options);
+        },
+      ),
+    );
 
-    ApiService({Dio? dio}) {
-    _dio = dio ?? Dio(BaseOptions(baseUrl: Env.current));
-
-    // 简单的日志拦截器
-    _dio.interceptors.add(LogInterceptor(
-      request: true,
-      responseBody: true,
-      error: true,
-    ));
+    _dio.interceptors.add(
+      LogInterceptor(
+        request: true,
+        responseBody: true,
+        error: true,
+      ),
+    );
   }
 
+  final Dio _dio;
+  final AuthService _auth;
+
+  Future<AuthenticatedUserDto> getAuthenticatedUserDetail() async {
+    try {
+      final response = await _dio.get('/User/GetAuthenticatedUserDetail');
+      if (response.statusCode == 200) {
+        final data = response.data;
+        if (data is Map<String, dynamic>) {
+          return AuthenticatedUserDto.fromJson(data);
+        }
+        throw ApiException('Unexpected user payload type');
+      }
+      throw ApiException(
+        'Failed to load user detail',
+        statusCode: response.statusCode,
+      );
+    } on DioException catch (e) {
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
+    }
+  }
 
   Future<List<Event>> getEvents() async {
     try {
-      final response = await _dio.get("/events");
+      final response = await _dio.get('/events');
       if (response.statusCode == 200) {
         return (response.data as List)
             .map((e) => Event.fromJson(e))
             .toList();
-      } else {
-        throw ApiException('Failed to load events',
-            statusCode: response.statusCode);
       }
+      throw ApiException(
+        'Failed to load events',
+        statusCode: response.statusCode,
+      );
     } on DioException catch (e) {
-      throw ApiException(e.message ?? 'Request error',
-          statusCode: e.response?.statusCode);
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
     }
   }
 
-  Future<Event> createEvent(String title, String location, String description,
-      double lat, double lng) async {
+  Future<Event> createEvent(
+    String title,
+    String location,
+    String description,
+    double lat,
+    double lng,
+  ) async {
     try {
-      final response = await _dio.post("/events", data: {
-        "title": title,
-        "location": location,
-        "description": description,
-        "latitude": lat,
-        "longitude": lng,
+      final response = await _dio.post('/events', data: {
+        'title': title,
+        'location': location,
+        'description': description,
+        'latitude': lat,
+        'longitude': lng,
       });
       if (response.statusCode == 200 || response.statusCode == 201) {
         return Event.fromJson(response.data);
-      } else {
-        throw ApiException('Failed to create event',
-            statusCode: response.statusCode);
       }
+      throw ApiException(
+        'Failed to create event',
+        statusCode: response.statusCode,
+      );
     } on DioException catch (e) {
-      throw ApiException(e.message ?? 'Request error',
-          statusCode: e.response?.statusCode);
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
     }
   }
 
   Future<List<Event>> searchEvents(String query) async {
     try {
       final response = await _dio.get(
-        "/events/search",
-        queryParameters: {"query": query},
+        '/events/search',
+        queryParameters: {'query': query},
       );
 
       if (response.statusCode == 200) {
         final List data = response.data;
         return data.map((e) => Event.fromJson(e)).toList();
-      } else {
-               throw ApiException('Failed to load events',
-            statusCode: response.statusCode);
       }
+      throw ApiException(
+        'Failed to load events',
+        statusCode: response.statusCode,
+      );
     } on DioException catch (e) {
-   throw ApiException(e.message ?? 'Request error',
-          statusCode: e.response?.statusCode);
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
     }
+  }
+
+  String? _extractErrorMessage(DioException exception) {
+    final data = exception.response?.data;
+    if (data is Map<String, dynamic>) {
+      final message = data['message'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+      final error = data['error'];
+      if (error is String && error.isNotEmpty) {
+        return error;
+      }
+    }
+    return exception.message;
   }
 }

--- a/lib/core/state/di/providers.dart
+++ b/lib/core/state/di/providers.dart
@@ -1,4 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../network/api_service.dart';
 
-final apiServiceProvider = Provider<ApiService>((ref) => ApiService());
+import '../../network/api_service.dart';
+import '../../network/auth/auth_service.dart';
+import '../../network/auth/firebase_auth_service.dart';
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  return FirebaseAuthService();
+});
+
+final apiServiceProvider = Provider<ApiService>((ref) {
+  return ApiService(
+    authService: ref.watch(authServiceProvider),
+  );
+});

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -12,6 +12,7 @@ import '../../data/event.dart';
 import '../../data/event_filter.dart';
 import '../../../../core/error/api_exception.dart';
 import '../../../../core/network/api_service.dart';
+import '../../../../core/state/di/providers.dart';
 import '../../../../core/state/event_map_state/events_providers.dart';
 import '../../../../core/state/event_map_state/location_provider.dart';
 import 'widgets/search_event_appbar.dart';
@@ -48,7 +49,7 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
   // 搜索框
   final _searchController = TextEditingController();
   late final FocusNode _searchFocusNode;
-  final _api = ApiService();
+  late final ApiService _api;
   EventFilter _filter = const EventFilter();
   List<Event> _searchResults = const <Event>[];
   bool _isSearching = false;
@@ -61,6 +62,7 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
   @override
   void initState() {
     super.initState();
+    _api = ref.read(apiServiceProvider);
     _searchFocusNode = FocusNode();
     _searchFocusNode.addListener(_onSearchFocusChanged);
     _mapFocusSubscription = ref.listenManual(

--- a/lib/features/user/data/authenticated_user_dto.dart
+++ b/lib/features/user/data/authenticated_user_dto.dart
@@ -1,0 +1,33 @@
+class AuthenticatedUserDto {
+  AuthenticatedUserDto({
+    required this.id,
+    required this.email,
+    this.displayName,
+    this.photoUrl,
+    this.roles = const [],
+    this.hasActiveSubscription = false,
+  });
+
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? photoUrl;
+  final List<String> roles;
+  final bool hasActiveSubscription;
+
+  factory AuthenticatedUserDto.fromJson(Map<String, dynamic> json) {
+    final subscription = json['subscription'];
+
+    return AuthenticatedUserDto(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String?,
+      photoUrl: json['photoUrl'] as String?,
+      roles: (json['roles'] as List<dynamic>? ?? const [])
+          .map((role) => role.toString())
+          .toList(),
+      hasActiveSubscription:
+          subscription is Map<String, dynamic> && subscription['isActive'] == true,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- register an injectable Firebase-backed AuthService and inject it into ApiService
- add automatic bearer token handling plus a helper to fetch the authenticated user profile
- fetch the Crew API user data after sign-in and parse it with a dedicated DTO
- update the events map page to resolve the missing AuthService injection by reading ApiService from Riverpod

## Testing
- not run (environment missing `dart` CLI)

------
https://chatgpt.com/codex/tasks/task_e_68e15fdbf5c0832c82259bdc94851f2b