### PR TITLE
Handle events without images

### DIFF
--- a/lib/features/events/data/event.dart
+++ b/lib/features/events/data/event.dart
@@ -33,4 +33,16 @@ class Event {
       coverImageUrl: json['coverImageUrl'] as String? ?? '',
     );
   }
+
+  /// Returns the first non-empty image URL among [imageUrls] and
+  /// [coverImageUrl]. If no URL is available, `null` is returned.
+  String? get firstAvailableImageUrl {
+    for (final url in [...imageUrls, coverImageUrl]) {
+      final trimmed = url.trim();
+      if (trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return null;
+  }
 }

--- a/lib/features/events/presentation/detail/widgets/event_image_carousel.dart
+++ b/lib/features/events/presentation/detail/widgets/event_image_carousel.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:crew_app/features/events/data/event.dart';
+import 'package:crew_app/features/events/presentation/widgets/event_image_placeholder.dart';
 import 'package:flutter/material.dart';
 
 class EventImageCarousel extends StatelessWidget {
@@ -18,19 +19,25 @@ class EventImageCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final images = event.imageUrls;
+    final images = event.imageUrls
+        .map((url) => url.trim())
+        .where((url) => url.isNotEmpty)
+        .toList();
+    final fallbackUrl = event.firstAvailableImageUrl;
+    final hasImages = images.isNotEmpty;
     return Stack(
       children: [
         AspectRatio(
           aspectRatio: 16 / 10,
           child: PageView.builder(
             controller: controller,
-            itemCount: images.isNotEmpty ? images.length : 1,
+            itemCount: hasImages ? images.length : 1,
             onPageChanged: onPageChanged,
             itemBuilder: (_, index) {
-              final imageUrl = images.isNotEmpty
-                  ? images[index]
-                  : event.coverImageUrl;
+              final imageUrl = hasImages ? images[index] : fallbackUrl;
+              if (imageUrl == null) {
+                return const EventImagePlaceholder(aspectRatio: 16 / 10);
+              }
               return CachedNetworkImage(
                 imageUrl: imageUrl,
                 width: double.infinity,

--- a/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
+++ b/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:crew_app/features/events/data/event.dart';
+import 'package:crew_app/features/events/presentation/widgets/event_image_placeholder.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -123,10 +124,7 @@ class SharePreviewCard extends StatelessWidget {
                 children: [
                   AspectRatio(
                     aspectRatio: 16 / 9,
-                    child: Image(
-                      image: CachedNetworkImageProvider(event.coverImageUrl),
-                      fit: BoxFit.cover,
-                    ),
+                    child: _SharePreviewImage(event: event),
                   ),
                   Positioned.fill(
                     child: DecoratedBox(
@@ -369,6 +367,29 @@ class _StatusChip extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _SharePreviewImage extends StatelessWidget {
+  final Event event;
+
+  const _SharePreviewImage({required this.event});
+
+  @override
+  Widget build(BuildContext context) {
+    final imageUrl = event.firstAvailableImageUrl;
+    if (imageUrl == null) {
+      return const EventImagePlaceholder();
+    }
+    return CachedNetworkImage(
+      imageUrl: imageUrl,
+      fit: BoxFit.cover,
+      width: double.infinity,
+      placeholder: (context, url) => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      errorWidget: (context, url, error) => const EventImagePlaceholder(),
     );
   }
 }

--- a/lib/features/events/presentation/list/events_list_page.dart
+++ b/lib/features/events/presentation/list/events_list_page.dart
@@ -147,19 +147,18 @@ class EventGridItem extends StatelessWidget {
             Hero(
               tag: heroTag,
               child: imageUrl != null
-                  ? AspectRatio(
-                      aspectRatio: 1,
-                      child: CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.cover,
-                        memCacheWidth: memCacheW,
-                        placeholder: (c, _) => const Center(
+                  ? CachedNetworkImage(
+                      imageUrl: imageUrl,
+                      fit: BoxFit.cover,
+                      memCacheWidth: memCacheW,
+                      placeholder: (c, _) => const AspectRatio(
+                        aspectRatio: 1,
+                        child: Center(
                           child: CircularProgressIndicator(strokeWidth: 2),
                         ),
-                        errorWidget: (c, _, __) => const Center(
-                          child: Icon(Icons.broken_image),
-                        ),
                       ),
+                      errorWidget: (c, _, __) =>
+                          const EventImagePlaceholder(aspectRatio: 1),
                     )
                   : const EventImagePlaceholder(aspectRatio: 1),
             ),

--- a/lib/features/events/presentation/list/events_list_page.dart
+++ b/lib/features/events/presentation/list/events_list_page.dart
@@ -1,9 +1,10 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:crew_app/features/events/data/event.dart';
+import 'package:crew_app/features/events/presentation/widgets/event_image_placeholder.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../../../core/state/app/app_overlay_provider.dart';
 import '../../../../core/error/api_exception.dart';
@@ -123,9 +124,7 @@ class EventGridItem extends StatelessWidget {
     final heroTag = 'event_$index';
      // Tips： 判断imageUrls是否有值，否则用coverImageUrl
     // (这是当前后端的问题，因为目前后端只有在创建的时候才会自动赋值coverImageUrl，而用SeedDataService预先插入的数据没用自动首页逻辑)，日后待看获取直接用event.coverImageUrl
-    final imageUrl = (event.imageUrls.isNotEmpty)
-        ? event.imageUrls.first
-        : event.coverImageUrl;
+    final imageUrl = event.firstAvailableImageUrl;
 
     return Material(
       elevation: 4,
@@ -147,20 +146,22 @@ class EventGridItem extends StatelessWidget {
           children: [
             Hero(
               tag: heroTag,
-              child: CachedNetworkImage(
-                imageUrl: imageUrl,
-                fit: BoxFit.cover,
-                memCacheWidth: memCacheW,
-                placeholder: (c, _) => const AspectRatio(
-                  aspectRatio: 1,
-                  child: Center(
-                      child: CircularProgressIndicator(strokeWidth: 2)),
-                ),
-                errorWidget: (c, _, __) => const AspectRatio(
-                  aspectRatio: 1,
-                  child: Center(child: Icon(Icons.broken_image)),
-                ),
-              ),
+              child: imageUrl != null
+                  ? AspectRatio(
+                      aspectRatio: 1,
+                      child: CachedNetworkImage(
+                        imageUrl: imageUrl,
+                        fit: BoxFit.cover,
+                        memCacheWidth: memCacheW,
+                        placeholder: (c, _) => const Center(
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                        errorWidget: (c, _, __) => const Center(
+                          child: Icon(Icons.broken_image),
+                        ),
+                      ),
+                    )
+                  : const EventImagePlaceholder(aspectRatio: 1),
             ),
             Positioned(
               left: 0,

--- a/lib/features/events/presentation/widgets/event_image_placeholder.dart
+++ b/lib/features/events/presentation/widgets/event_image_placeholder.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class EventImagePlaceholder extends StatelessWidget {
+  final double? aspectRatio;
+  final IconData icon;
+
+  const EventImagePlaceholder({
+    super.key,
+    this.aspectRatio,
+    this.icon = Icons.image_not_supported_outlined,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholder = DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.grey.shade200,
+      ),
+      child: Center(
+        child: Icon(
+          icon,
+          color: Colors.grey.shade500,
+          size: 48,
+        ),
+      ),
+    );
+
+    if (aspectRatio != null) {
+      return AspectRatio(
+        aspectRatio: aspectRatio!,
+        child: placeholder,
+      );
+    }
+
+    return placeholder;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable placeholder widget and helper for choosing the first valid event image URL
- update the events grid, detail carousel, and share sheet to fall back to the placeholder when no remote image is available

## Testing
- Not run (Flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1880610ac832cb520b6758e14a7a6