### PR TITLE
Show real event hosts on the detail page

### DIFF
--- a/lib/features/events/data/event.dart
+++ b/lib/features/events/data/event.dart
@@ -7,6 +7,11 @@ class Event {
   final double longitude;
   final List<String> imageUrls;
   final String coverImageUrl;
+  final EventUserSummary? createdByUser;
+  final String? createdByUserId;
+  final String? createdByUserName;
+  final String? createdByUserPhotoUrl;
+  final String? createdByUserBio;
 
   Event({
     required this.id,
@@ -17,9 +22,58 @@ class Event {
     required this.longitude,
     required this.imageUrls,
     required this.coverImageUrl,
+    this.createdByUser,
+    this.createdByUserId,
+    this.createdByUserName,
+    this.createdByUserPhotoUrl,
+    this.createdByUserBio,
   });
 
   factory Event.fromJson(Map<String, dynamic> json) {
+    String? _readString(dynamic value) {
+      if (value is String) {
+        final trimmed = value.trim();
+        return trimmed.isEmpty ? null : trimmed;
+      }
+      return null;
+    }
+
+    EventUserSummary? _readUserSummary(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return EventUserSummary.fromJson(value);
+      }
+      return null;
+    }
+
+    final createdBy = _readUserSummary(
+      json['createdByUser'] ?? json['createdBy'] ?? json['creator'],
+    );
+
+    final createdById = _readString(json['createdByUserId']) ??
+        _readString(json['createdById']) ??
+        _readString(json['creatorId']) ??
+        createdBy?.id;
+
+    final createdByName = _readString(json['createdByUserName']) ??
+        _readString(json['createdByName']) ??
+        _readString(json['creatorName']) ??
+        _readString(json['organizerName']) ??
+        createdBy?.displayName ??
+        createdBy?.name;
+
+    final createdByPhoto = _readString(json['createdByUserPhotoUrl']) ??
+        _readString(json['createdByPhotoUrl']) ??
+        _readString(json['creatorPhotoUrl']) ??
+        _readString(json['organizerAvatar']) ??
+        _readString(json['avatarUrl']) ??
+        createdBy?.photoUrl;
+
+    final createdByBio = _readString(json['createdByUserBio']) ??
+        _readString(json['createdByBio']) ??
+        _readString(json['creatorBio']) ??
+        _readString(json['organizerBio']) ??
+        createdBy?.bio;
+
     return Event(
       id: json['id'] as int,
       title: json['title'] as String,
@@ -31,6 +85,11 @@ class Event {
           .map((e) => e.toString())
           .toList(),
       coverImageUrl: json['coverImageUrl'] as String? ?? '',
+      createdByUser: createdBy,
+      createdByUserId: createdById,
+      createdByUserName: createdByName,
+      createdByUserPhotoUrl: createdByPhoto,
+      createdByUserBio: createdByBio,
     );
   }
 
@@ -44,5 +103,97 @@ class Event {
       }
     }
     return null;
+  }
+
+  String? get hostDisplayName {
+    final candidates = [
+      createdByUser?.displayName,
+      createdByUserName,
+      createdByUser?.name,
+      createdByUser?.email,
+    ];
+    for (final value in candidates) {
+      final trimmed = value?.trim();
+      if (trimmed != null && trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return null;
+  }
+
+  String? get hostBio {
+    final candidates = [createdByUser?.bio, createdByUserBio];
+    for (final value in candidates) {
+      final trimmed = value?.trim();
+      if (trimmed != null && trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return null;
+  }
+
+  String? get hostAvatarUrl {
+    final candidates = [createdByUser?.photoUrl, createdByUserPhotoUrl];
+    for (final value in candidates) {
+      final trimmed = value?.trim();
+      if (trimmed != null && trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return null;
+  }
+
+  String? get hostUserId => createdByUser?.id ?? createdByUserId;
+}
+
+class EventUserSummary {
+  const EventUserSummary({
+    required this.id,
+    this.displayName,
+    this.name,
+    this.email,
+    this.photoUrl,
+    this.bio,
+  });
+
+  final String id;
+  final String? displayName;
+  final String? name;
+  final String? email;
+  final String? photoUrl;
+  final String? bio;
+
+  factory EventUserSummary.fromJson(Map<String, dynamic> json) {
+    String? _readString(dynamic value) {
+      if (value is String) {
+        final trimmed = value.trim();
+        return trimmed.isEmpty ? null : trimmed;
+      }
+      return null;
+    }
+
+    final id = _readString(json['id']) ??
+        _readString(json['userId']) ??
+        _readString(json['uid']) ??
+        _readString(json['identifier']) ??
+        'unknown';
+
+    return EventUserSummary(
+      id: id,
+      displayName: _readString(json['displayName']) ??
+          _readString(json['nickName']) ??
+          _readString(json['userName']) ??
+          _readString(json['username']),
+      name: _readString(json['name']) ?? _readString(json['fullName']),
+      email: _readString(json['email']),
+      photoUrl: _readString(json['photoUrl']) ??
+          _readString(json['avatarUrl']) ??
+          _readString(json['avatar']) ??
+          _readString(json['profileImageUrl']),
+      bio: _readString(json['bio']) ??
+          _readString(json['about']) ??
+          _readString(json['headline']) ??
+          _readString(json['description']),
+    );
   }
 }

--- a/lib/features/events/presentation/detail/events_detail_page.dart
+++ b/lib/features/events/presentation/detail/events_detail_page.dart
@@ -26,16 +26,21 @@ class _EventDetailPageState extends State<EventDetailPage> {
   int _page = 0;
   final GlobalKey _sharePreviewKey = GlobalKey();
 
-  final _host = (
-    name: 'Luca B.',
-    bio: 'Milan · 徒步/咖啡/摄影',
-    avatar: 'https://images.unsplash.com/photo-1502685104226-ee32379fefbe',
-    userId: 'user_123',
-  );
-
   bool _following = false;
 
   String get _eventShareLink => 'https://crewapp.events/${widget.event.id}';
+
+  String _resolveHostName(AppLocalizations loc) {
+    return widget.event.hostDisplayName ?? loc.events_host_default_name;
+  }
+
+  String _resolveHostBio(AppLocalizations loc) {
+    return widget.event.hostBio ?? loc.events_host_default_bio;
+  }
+
+  String? _resolveHostAvatar() {
+    return widget.event.hostAvatarUrl;
+  }
 
   String _buildShareMessage() {
     final event = widget.event;
@@ -184,13 +189,15 @@ class _EventDetailPageState extends State<EventDetailPage> {
         pageController: _pageCtrl,
         currentPage: _page,
         onPageChanged: (index) => setState(() => _page = index),
-        hostName: _host.name,
-        hostBio: _host.bio,
-        hostAvatarUrl: _host.avatar,
+        hostName: _resolveHostName(loc),
+        hostBio: _resolveHostBio(loc),
+        hostAvatarUrl: _resolveHostAvatar(),
         onTapHostProfile: () {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => UserProfilePage(/*userId: _host.userId*/)),
+            MaterialPageRoute(
+              builder: (_) => const UserProfilePage(/* userId: */),
+            ),
           );
         },
         onToggleFollow: () async {

--- a/lib/features/events/presentation/detail/widgets/event_detail_body.dart
+++ b/lib/features/events/presentation/detail/widgets/event_detail_body.dart
@@ -14,7 +14,7 @@ class EventDetailBody extends StatelessWidget {
   final ValueChanged<int> onPageChanged;
   final String hostName;
   final String hostBio;
-  final String hostAvatarUrl;
+  final String? hostAvatarUrl;
   final VoidCallback onTapHostProfile;
   final VoidCallback onToggleFollow;
   final bool isFollowing;

--- a/lib/features/events/presentation/detail/widgets/event_host_card.dart
+++ b/lib/features/events/presentation/detail/widgets/event_host_card.dart
@@ -6,7 +6,7 @@ class EventHostCard extends StatelessWidget {
   final AppLocalizations loc;
   final String name;
   final String bio;
-  final String avatarUrl;
+  final String? avatarUrl;
   final VoidCallback onTapProfile;
   final VoidCallback onToggleFollow;
   final bool isFollowing;
@@ -37,8 +37,8 @@ class EventHostCard extends StatelessWidget {
             children: [
               CircleAvatar(
                 radius: 28,
-                backgroundImage: CachedNetworkImageProvider(avatarUrl),
                 backgroundColor: Colors.orange.shade50,
+                backgroundImage: _buildAvatarImage(),
               ),
               const SizedBox(width: 12),
               Expanded(
@@ -96,5 +96,13 @@ class EventHostCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  ImageProvider<Object> _buildAvatarImage() {
+    final url = avatarUrl?.trim();
+    if (url != null && url.isNotEmpty) {
+      return CachedNetworkImageProvider(url);
+    }
+    return const AssetImage('assets/images/icons/crew.png');
   }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -302,6 +302,18 @@ abstract class AppLocalizations {
   /// **'Event details'**
   String get event_details_title;
 
+  /// Fallback text for the event host name when user information is missing.
+  ///
+  /// In en, this message translates to:
+  /// **'Crew member'**
+  String get events_host_default_name;
+
+  /// Fallback biography for the event host when no profile description is available.
+  ///
+  /// In en, this message translates to:
+  /// **'Crew community event host'**
+  String get events_host_default_bio;
+
   /// No description provided for @event_meeting_point_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -116,6 +116,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get event_details_title => 'Event details';
 
   @override
+  String get events_host_default_name => 'Crew member';
+
+  @override
+  String get events_host_default_bio => 'Crew community event host';
+
+  @override
   String get event_meeting_point_title => 'Meeting point';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -115,6 +115,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get event_details_title => '活动详情';
 
   @override
+  String get events_host_default_name => 'Crew 用户';
+
+  @override
+  String get events_host_default_bio => 'Crew 社区活动发起人';
+
+  @override
   String get event_meeting_point_title => '集合地点';
 
   @override

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -44,6 +44,14 @@
   "events": "Events",
   "event_description_field_label": "Event Description",
   "event_details_title": "Event details",
+  "events_host_default_name": "Crew member",
+  "@events_host_default_name": {
+    "description": "Fallback text for event host name when the backend does not provide one"
+  },
+  "events_host_default_bio": "Crew community event host",
+  "@events_host_default_bio": {
+    "description": "Fallback biography shown for event hosts when user information is missing"
+  },
   "event_meeting_point_title": "Meeting point",
   "event_participants_title": "Participants",
   "event_time_title": "Event time",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -86,6 +86,14 @@
   "events": "活动",
   "event_description_field_label": "活动描述",
   "event_details_title": "活动详情",
+  "events_host_default_name": "Crew 用户",
+  "@events_host_default_name": {
+    "description": "当后端未返回活动发起人名称时的默认文案"
+  },
+  "events_host_default_bio": "Crew 社区活动发起人",
+  "@events_host_default_bio": {
+    "description": "当后端缺少发起人简介时展示的默认说明"
+  },
   "event_meeting_point_title": "集合地点",
   "event_participants_title": "参与人数",
   "event_time_title": "活动时间",


### PR DESCRIPTION
## Summary
- parse host user information from event API payloads and expose convenient helpers on the `Event` model
- surface the authenticated host on the event detail page with localized fallbacks and a default avatar
- add localization strings for the new host defaults in both English and Chinese

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e19cff7d4c832ca75ab503ba40d83d