### PR TITLE
Integrate profile providers with Crew API

### DIFF
--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -2,6 +2,7 @@ import 'package:crew_app/core/config/environment.dart';
 import 'package:dio/dio.dart';
 
 import '../../features/events/data/event.dart';
+import '../../features/user/data/activity_item.dart';
 import '../../features/user/data/authenticated_user_dto.dart';
 import '../error/api_exception.dart';
 import 'auth/auth_service.dart';
@@ -66,6 +67,70 @@ class ApiService {
       }
       throw ApiException(
         'Failed to load user detail',
+        statusCode: response.statusCode,
+      );
+    } on ApiException {
+      rethrow;
+    } on DioException catch (e) {
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
+    }
+  }
+
+  Future<List<ActivityItem>> getUserEvents() async {
+    try {
+      final headers = await _buildAuthHeaders(required: true);
+      final response = await _dio.get(
+        '/Event/MyEvents',
+        options: Options(headers: headers),
+      );
+      if (response.statusCode == 200) {
+        final data = response.data;
+        if (data is List) {
+          return data
+              .whereType<Map>()
+              .map((e) => ActivityItem.fromJson(Map<String, dynamic>.from(e)))
+              .toList();
+        }
+        throw ApiException('Unexpected my events payload type');
+      }
+      throw ApiException(
+        'Failed to load my events',
+        statusCode: response.statusCode,
+      );
+    } on ApiException {
+      rethrow;
+    } on DioException catch (e) {
+      final message = _extractErrorMessage(e) ?? 'Request error';
+      throw ApiException(
+        message,
+        statusCode: e.response?.statusCode,
+      );
+    }
+  }
+
+  Future<List<Event>> getUserFavoriteEvents() async {
+    try {
+      final headers = await _buildAuthHeaders(required: true);
+      final response = await _dio.get(
+        '/Event/MyFavorites',
+        options: Options(headers: headers),
+      );
+      if (response.statusCode == 200) {
+        final data = response.data;
+        if (data is List) {
+          return data
+              .whereType<Map>()
+              .map((e) => Event.fromJson(Map<String, dynamic>.from(e)))
+              .toList();
+        }
+        throw ApiException('Unexpected favorites payload type');
+      }
+      throw ApiException(
+        'Failed to load favorite events',
         statusCode: response.statusCode,
       );
     } on ApiException {

--- a/lib/features/events/data/event.dart
+++ b/lib/features/events/data/event.dart
@@ -7,6 +7,7 @@ class Event {
   final double longitude;
   final List<String> imageUrls;
   final String coverImageUrl;
+  final DateTime? startTime;
 
   Event({
     required this.id,
@@ -17,9 +18,17 @@ class Event {
     required this.longitude,
     required this.imageUrls,
     required this.coverImageUrl,
+    this.startTime,
   });
 
   factory Event.fromJson(Map<String, dynamic> json) {
+    DateTime? startTime;
+    final rawStart = json['startTime'] ?? json['start_time'] ?? json['scheduledAt'];
+    if (rawStart is String && rawStart.isNotEmpty) {
+      startTime = DateTime.tryParse(rawStart);
+    } else if (rawStart is int) {
+      startTime = DateTime.fromMillisecondsSinceEpoch(rawStart);
+    }
     return Event(
       id: json['id'] as int,
       title: json['title'] as String,
@@ -31,6 +40,7 @@ class Event {
           .map((e) => e.toString())
           .toList(),
       coverImageUrl: json['coverImageUrl'] as String? ?? '',
+      startTime: startTime,
     );
   }
 

--- a/lib/features/user/data/activity_item.dart
+++ b/lib/features/user/data/activity_item.dart
@@ -2,14 +2,49 @@
 class ActivityItem {
   final String id;
   final String title;
-  final String imageUrl;
-  final DateTime time;
-  final String location;
-  ActivityItem({
+  final String? imageUrl;
+  final DateTime? time;
+  final String? location;
+
+  const ActivityItem({
     required this.id,
     required this.title,
-    required this.imageUrl,
-    required this.time,
-    required this.location,
+    this.imageUrl,
+    this.time,
+    this.location,
   });
+
+  factory ActivityItem.fromJson(Map<String, dynamic> json) {
+    DateTime? parsedTime;
+    final rawTime = json['startTime'] ?? json['start_time'] ?? json['time'];
+    if (rawTime is String && rawTime.isNotEmpty) {
+      parsedTime = DateTime.tryParse(rawTime);
+    } else if (rawTime is int) {
+      parsedTime = DateTime.fromMillisecondsSinceEpoch(rawTime);
+    }
+
+    String? imageUrl;
+    final images = json['imageUrls'] ?? json['images'];
+    if (json['coverImageUrl'] is String && (json['coverImageUrl'] as String).isNotEmpty) {
+      imageUrl = json['coverImageUrl'] as String;
+    } else if (json['cover'] is String && (json['cover'] as String).isNotEmpty) {
+      imageUrl = json['cover'] as String;
+    } else if (images is List) {
+      for (final item in images) {
+        final candidate = item?.toString();
+        if (candidate != null && candidate.trim().isNotEmpty) {
+          imageUrl = candidate;
+          break;
+        }
+      }
+    }
+
+    return ActivityItem(
+      id: json['id']?.toString() ?? '',
+      title: json['title']?.toString() ?? json['name']?.toString() ?? '',
+      imageUrl: imageUrl,
+      time: parsedTime,
+      location: json['location']?.toString() ?? json['locationName']?.toString(),
+    );
+  }
 }

--- a/lib/features/user/data/authenticated_user_dto.dart
+++ b/lib/features/user/data/authenticated_user_dto.dart
@@ -4,6 +4,12 @@ class AuthenticatedUserDto {
     required this.email,
     this.displayName,
     this.photoUrl,
+    this.coverUrl,
+    this.bio,
+    this.followers,
+    this.following,
+    this.likes,
+    this.isFollowed,
     this.roles = const [],
     this.hasActiveSubscription = false,
   });
@@ -12,22 +18,70 @@ class AuthenticatedUserDto {
   final String email;
   final String? displayName;
   final String? photoUrl;
+  final String? coverUrl;
+  final String? bio;
+  final int? followers;
+  final int? following;
+  final int? likes;
+  final bool? isFollowed;
   final List<String> roles;
   final bool hasActiveSubscription;
 
   factory AuthenticatedUserDto.fromJson(Map<String, dynamic> json) {
     final subscription = json['subscription'];
+    final profile = json['profile'] as Map<String, dynamic>?;
+    final stats = json['stats'] as Map<String, dynamic>?;
 
     return AuthenticatedUserDto(
       id: json['id'] as String,
       email: json['email'] as String,
       displayName: json['displayName'] as String?,
       photoUrl: json['photoUrl'] as String?,
+      coverUrl: _readString(profile, 'coverUrl') ?? json['coverUrl'] as String?,
+      bio: _readString(profile, 'bio') ?? json['bio'] as String?,
+      followers: _readInt(stats, 'followers') ?? _readInt(profile, 'followers'),
+      following: _readInt(stats, 'following') ?? _readInt(profile, 'following'),
+      likes: _readInt(stats, 'likes') ?? _readInt(profile, 'likes'),
+      isFollowed: _readBool(json, 'isFollowed') ?? _readBool(profile, 'followed'),
       roles: (json['roles'] as List<dynamic>? ?? const [])
           .map((role) => role.toString())
           .toList(),
       hasActiveSubscription:
           subscription is Map<String, dynamic> && subscription['isActive'] == true,
     );
+  }
+
+  static String? _readString(Map<String, dynamic>? json, String key) {
+    final value = json?[key];
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return null;
+  }
+
+  static int? _readInt(Map<String, dynamic>? json, String key) {
+    final value = json?[key];
+    if (value is int) {
+      return value;
+    }
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return null;
+  }
+
+  static bool? _readBool(Map<String, dynamic>? json, String key) {
+    final value = json?[key];
+    if (value is bool) {
+      return value;
+    }
+    if (value is String) {
+      if (value.toLowerCase() == 'true') return true;
+      if (value.toLowerCase() == 'false') return false;
+    }
+    return null;
   }
 }

--- a/lib/features/user/data/user.dart
+++ b/lib/features/user/data/user.dart
@@ -1,35 +1,47 @@
 class User {
   final String uid;
   final String name;
-  final String bio;
-  final String avatar;
-  final String cover;
+  final String? bio;
+  final String? avatar;
+  final String? cover;
   final int followers;
   final int following;
   final int likes;
   final bool followed;
-  User({
+
+  const User({
     required this.uid,
     required this.name,
-    required this.bio,
-    required this.avatar,
-    required this.cover,
-    required this.followers,
-    required this.following,
-    required this.likes,
-    required this.followed,
+    this.bio,
+    this.avatar,
+    this.cover,
+    this.followers = 0,
+    this.following = 0,
+    this.likes = 0,
+    this.followed = false,
   });
 
-  User copyWith({bool? followed, int? followers}) => User(
-        uid: uid,
-        name: name,
-        bio: bio,
-        avatar: avatar,
-        cover: cover,
-        followers: followers ?? this.followers,
-        following: following,
-        likes: likes,
-        followed: followed ?? this.followed,
-      );
+  User copyWith({
+    String? name,
+    String? bio,
+    String? avatar,
+    String? cover,
+    int? followers,
+    int? following,
+    int? likes,
+    bool? followed,
+  }) {
+    return User(
+      uid: uid,
+      name: name ?? this.name,
+      bio: bio ?? this.bio,
+      avatar: avatar ?? this.avatar,
+      cover: cover ?? this.cover,
+      followers: followers ?? this.followers,
+      following: following ?? this.following,
+      likes: likes ?? this.likes,
+      followed: followed ?? this.followed,
+    );
+  }
 }
 


### PR DESCRIPTION
## Summary
- fetch the authenticated user profile with an AsyncNotifier and surface loading/error states in the header
- expose Crew API "My Events" and "My Favorites" endpoints via new providers and wire them into the tab content with proper placeholders
- normalize nullable assets and metadata (avatar, cover, stats, timings) so the profile UI is resilient to missing fields

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27887fe68832c81a777766ab081f5