### PR TITLE
Fetch host profile data on event detail page

### DIFF
--- a/lib/features/events/presentation/detail/widgets/event_detail_body.dart
+++ b/lib/features/events/presentation/detail/widgets/event_detail_body.dart
@@ -19,6 +19,7 @@ class EventDetailBody extends StatelessWidget {
   final VoidCallback onToggleFollow;
   final bool isFollowing;
   final VoidCallback onTapLocation;
+  final bool isHostLoading;
 
   const EventDetailBody({
     super.key,
@@ -34,6 +35,7 @@ class EventDetailBody extends StatelessWidget {
     required this.onToggleFollow,
     required this.isFollowing,
     required this.onTapLocation,
+    this.isHostLoading = false,
   });
 
   @override
@@ -57,6 +59,7 @@ class EventDetailBody extends StatelessWidget {
             onTapProfile: onTapHostProfile,
             onToggleFollow: onToggleFollow,
             isFollowing: isFollowing,
+            isLoading: isHostLoading,
           ),
           const SizedBox(height: 10),
           SizedBox(

--- a/lib/features/events/presentation/detail/widgets/event_host_card.dart
+++ b/lib/features/events/presentation/detail/widgets/event_host_card.dart
@@ -10,6 +10,7 @@ class EventHostCard extends StatelessWidget {
   final VoidCallback onTapProfile;
   final VoidCallback onToggleFollow;
   final bool isFollowing;
+  final bool isLoading;
 
   const EventHostCard({
     super.key,
@@ -20,6 +21,7 @@ class EventHostCard extends StatelessWidget {
     required this.onTapProfile,
     required this.onToggleFollow,
     required this.isFollowing,
+    this.isLoading = false,
   });
 
   @override
@@ -74,31 +76,54 @@ class EventHostCard extends StatelessWidget {
               const SizedBox(width: 8),
               SizedBox(
                 height: 36,
-                child: isFollowing
-                    ? OutlinedButton.icon(
-                        onPressed: onToggleFollow,
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor: Colors.orange,
-                          side: BorderSide(color: Colors.orange.shade300),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 200),
+                  switchInCurve: Curves.easeOut,
+                  switchOutCurve: Curves.easeIn,
+                  child: isLoading
+                      ? SizedBox(
+                          key: const ValueKey('host_loading'),
+                          width: 36,
+                          child: Center(
+                            child: SizedBox(
+                              width: 22,
+                              height: 22,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2.4,
+                                color: Colors.orange.shade400,
+                              ),
+                            ),
                           ),
-                        ),
-                        icon: const Icon(Icons.check, size: 18),
-                        label: Text(loc.action_following),
-                      )
-                    : ElevatedButton.icon(
-                        onPressed: onToggleFollow,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.orange,
-                          foregroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                        ),
-                        icon: const Icon(Icons.person_add_alt_1, size: 18),
-                        label: Text(loc.action_follow),
-                      ),
+                        )
+                      : isFollowing
+                          ? OutlinedButton.icon(
+                              key: const ValueKey('host_following'),
+                              onPressed: onToggleFollow,
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: Colors.orange,
+                                side:
+                                    BorderSide(color: Colors.orange.shade300),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                              ),
+                              icon: const Icon(Icons.check, size: 18),
+                              label: Text(loc.action_following),
+                            )
+                          : ElevatedButton.icon(
+                              key: const ValueKey('host_follow'),
+                              onPressed: onToggleFollow,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.orange,
+                                foregroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                              ),
+                              icon: const Icon(Icons.person_add_alt_1, size: 18),
+                              label: Text(loc.action_follow),
+                            ),
+                ),
               ),
             ],
           ),

--- a/lib/features/user/data/user_profile_summary.dart
+++ b/lib/features/user/data/user_profile_summary.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class UserProfileSummary {
+  final String id;
+  final String name;
+  final String? bio;
+  final String? avatarUrl;
+  final String? coverImageUrl;
+  final int? followers;
+  final int? following;
+  final int? likes;
+  final bool? isFollowing;
+
+  const UserProfileSummary({
+    required this.id,
+    required this.name,
+    this.bio,
+    this.avatarUrl,
+    this.coverImageUrl,
+    this.followers,
+    this.following,
+    this.likes,
+    this.isFollowing,
+  });
+
+  factory UserProfileSummary.fromJson(Map<String, dynamic> json) {
+    Map<String, dynamic>? asMap(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return value;
+      }
+      if (value is Map) {
+        return value.map((key, value) => MapEntry(key.toString(), value));
+      }
+      return null;
+    }
+
+    String? parseString(dynamic value) {
+      if (value == null) return null;
+      final str = value.toString().trim();
+      return str.isEmpty ? null : str;
+    }
+
+    int? parseInt(dynamic value) {
+      if (value == null) return null;
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      return int.tryParse(value.toString());
+    }
+
+    bool? parseBool(dynamic value) {
+      if (value == null) return null;
+      if (value is bool) return value;
+      if (value is num) return value != 0;
+      final lower = value.toString().toLowerCase();
+      if (lower == 'true' || lower == 'yes' || lower == '1') {
+        return true;
+      }
+      if (lower == 'false' || lower == 'no' || lower == '0') {
+        return false;
+      }
+      return null;
+    }
+
+    final profile =
+        asMap(json['profile']) ?? asMap(json['userProfile']) ?? asMap(json['detail']);
+    final stats = asMap(json['stats']) ??
+        asMap(json['statistics']) ??
+        asMap(json['counts']) ??
+        asMap(json['metrics']);
+
+    final id = parseString(
+          json['id'] ??
+              json['uid'] ??
+              json['userId'] ??
+              json['ownerId'] ??
+              profile?['id'] ??
+              profile?['uid'],
+        ) ??
+        '';
+
+    final name = parseString(
+          json['name'] ??
+              json['displayName'] ??
+              json['nickname'] ??
+              json['userName'] ??
+              json['fullName'] ??
+              profile?['name'] ??
+              profile?['displayName'],
+        ) ??
+        '';
+
+    return UserProfileSummary(
+      id: id,
+      name: name,
+      bio: parseString(json['bio'] ?? profile?['bio'] ?? json['introduction']),
+      avatarUrl: parseString(
+        json['avatarUrl'] ??
+            json['avatar'] ??
+            json['profileImage'] ??
+            json['photoUrl'] ??
+            profile?['avatarUrl'] ??
+            profile?['photoUrl'],
+      ),
+      coverImageUrl: parseString(
+        json['coverImage'] ??
+            json['coverImageUrl'] ??
+            json['coverUrl'] ??
+            profile?['coverImage'] ??
+            profile?['cover'],
+      ),
+      followers: parseInt(
+        json['followers'] ??
+            json['followersCount'] ??
+            stats?['followers'] ??
+            stats?['followerCount'] ??
+            stats?['followersCount'],
+      ),
+      following: parseInt(
+        json['following'] ??
+            json['followingCount'] ??
+            stats?['following'] ??
+            stats?['followingCount'],
+      ),
+      likes: parseInt(
+        json['likes'] ??
+            json['likesCount'] ??
+            stats?['likes'] ??
+            stats?['likesCount'] ??
+            stats?['likeCount'],
+      ),
+      isFollowing: parseBool(
+        json['isFollowing'] ??
+            json['followed'] ??
+            json['isFollowed'] ??
+            stats?['isFollowing'] ??
+            stats?['followed'],
+      ),
+    );
+  }
+
+  UserProfileSummary copyWith({
+    String? id,
+    String? name,
+    String? bio,
+    String? avatarUrl,
+    String? coverImageUrl,
+    int? followers,
+    int? following,
+    int? likes,
+    bool? isFollowing,
+  }) {
+    return UserProfileSummary(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bio: bio ?? this.bio,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      coverImageUrl: coverImageUrl ?? this.coverImageUrl,
+      followers: followers ?? this.followers,
+      following: following ?? this.following,
+      likes: likes ?? this.likes,
+      isFollowing: isFollowing ?? this.isFollowing,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an API service helper and model to load host profile details from /Users/{id}
- fetch organizer information when opening the event detail page and surface errors gracefully
- improve the host card UI with loading feedback while the profile data is retrieved

## Testing
- not run (flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2a3143a1c832cbc2772a446c3eb29