### PR TITLE
Integrate follow and favorites flows with backend

### DIFF
--- a/lib/features/events/data/event.dart
+++ b/lib/features/events/data/event.dart
@@ -4,6 +4,7 @@ class EventOrganizer {
   final String? avatarUrl;
   final String? bio;
   final String? username;
+  final bool isFollowed;
 
   const EventOrganizer({
     required this.id,
@@ -11,11 +12,28 @@ class EventOrganizer {
     this.avatarUrl,
     this.bio,
     this.username,
+    this.isFollowed = false,
   });
 
   factory EventOrganizer.fromJson(Map<String, dynamic> json) {
     final profile = _asMap(json['profile']);
     String? parseString(dynamic value) => value?.toString();
+    bool? parseBool(dynamic value) {
+      if (value is bool) return value;
+      if (value is String) {
+        final normalized = value.toLowerCase();
+        if (normalized == 'true' || normalized == '1') {
+          return true;
+        }
+        if (normalized == 'false' || normalized == '0') {
+          return false;
+        }
+      }
+      if (value is num) {
+        return value != 0;
+      }
+      return null;
+    }
     return EventOrganizer(
       id: parseString(
             json['id'] ??
@@ -44,6 +62,13 @@ class EventOrganizer {
       ),
       bio: parseString(json['bio'] ?? profile?['bio']),
       username: parseString(json['userName'] ?? profile?['userName']),
+      isFollowed: parseBool(
+            json['isFollowed'] ??
+                json['followed'] ??
+                json['isFollowing'] ??
+                profile?['isFollowed'],
+          ) ??
+          false,
     );
   }
 
@@ -53,7 +78,17 @@ class EventOrganizer {
         if (avatarUrl != null) 'avatarUrl': avatarUrl,
         if (bio != null) 'bio': bio,
         if (username != null) 'userName': username,
+        'isFollowed': isFollowed,
       };
+
+  EventOrganizer copyWith({bool? isFollowed}) => EventOrganizer(
+        id: id,
+        name: name,
+        avatarUrl: avatarUrl,
+        bio: bio,
+        username: username,
+        isFollowed: isFollowed ?? this.isFollowed,
+      );
 }
 
 class Event {
@@ -102,6 +137,53 @@ class Event {
     this.tags = const <String>[],
     this.organizer,
   });
+
+  Event copyWith({
+    String? id,
+    String? title,
+    String? location,
+    String? description,
+    double? latitude,
+    double? longitude,
+    List<String>? imageUrls,
+    String? coverImageUrl,
+    String? address,
+    DateTime? startTime,
+    DateTime? endTime,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    int? maxParticipants,
+    int? currentParticipants,
+    bool? isFavorite,
+    bool? isRegistered,
+    bool? isFree,
+    double? price,
+    List<String>? tags,
+    EventOrganizer? organizer,
+  }) =>
+      Event(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        location: location ?? this.location,
+        description: description ?? this.description,
+        latitude: latitude ?? this.latitude,
+        longitude: longitude ?? this.longitude,
+        imageUrls: imageUrls ?? this.imageUrls,
+        coverImageUrl: coverImageUrl ?? this.coverImageUrl,
+        address: address ?? this.address,
+        startTime: startTime ?? this.startTime,
+        endTime: endTime ?? this.endTime,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+        maxParticipants: maxParticipants ?? this.maxParticipants,
+        currentParticipants: currentParticipants ?? this.currentParticipants,
+        isFavorite: isFavorite ?? this.isFavorite,
+        isRegistered: isRegistered ?? this.isRegistered,
+        isFree: isFree ?? this.isFree,
+        price: price ?? this.price,
+        tags: tags ?? this.tags,
+        organizer: organizer ?? this.organizer,
+      );
 
   factory Event.fromJson(Map<String, dynamic> json) {
     final locationJson = _asMap(json['location']) ?? _asMap(json['meetingPoint']);

--- a/lib/features/events/presentation/detail/events_detail_page.dart
+++ b/lib/features/events/presentation/detail/events_detail_page.dart
@@ -2,26 +2,32 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:crew_app/features/events/data/event.dart';
+import 'package:crew_app/core/error/api_exception.dart';
+import 'package:crew_app/core/state/auth/auth_providers.dart';
+import 'package:crew_app/core/state/di/providers.dart';
+import 'package:crew_app/core/state/event_map_state/events_providers.dart';
 import 'package:crew_app/features/events/presentation/detail/widgets/event_detail_app_bar.dart';
 import 'package:crew_app/features/events/presentation/detail/widgets/event_detail_body.dart';
 import 'package:crew_app/features/events/presentation/detail/widgets/event_detail_bottom_bar.dart';
 import 'package:crew_app/features/events/presentation/detail/widgets/event_share_sheet.dart';
+import 'package:crew_app/features/profile/data/favorites_provider.dart';
 import 'package:crew_app/features/user/presentation/user_profile_page.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:image_gallery_saver_plus/image_gallery_saver_plus.dart';
 
-class EventDetailPage extends StatefulWidget {
+class EventDetailPage extends ConsumerStatefulWidget {
   final Event event;
   const EventDetailPage({super.key, required this.event});
 
   @override
-  State<EventDetailPage> createState() => _EventDetailPageState();
+  ConsumerState<EventDetailPage> createState() => _EventDetailPageState();
 }
 
-class _EventDetailPageState extends State<EventDetailPage> {
+class _EventDetailPageState extends ConsumerState<EventDetailPage> {
   final PageController _pageCtrl = PageController();
   int _page = 0;
   final GlobalKey _sharePreviewKey = GlobalKey();
@@ -32,13 +38,25 @@ class _EventDetailPageState extends State<EventDetailPage> {
     avatar: 'https://images.unsplash.com/photo-1502685104226-ee32379fefbe',
   );
 
-  bool _following = false;
+  late Event _event;
+  late bool _isFavorite;
+  late bool _isFollowing;
+  bool _favoriteLoading = false;
+  bool _followLoading = false;
 
   String get _eventShareLink => 'https://crewapp.events/${widget.event.id}';
 
   String _buildShareMessage() {
     final event = widget.event;
     return '${event.title} · ${event.location}\n$_eventShareLink';
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _event = widget.event;
+    _isFavorite = widget.event.isFavorite;
+    _isFollowing = widget.event.organizer?.isFollowed ?? false;
   }
 
   void _showShareSheet(BuildContext context) {
@@ -144,9 +162,108 @@ class _EventDetailPageState extends State<EventDetailPage> {
     }
   }
 
-  void _onFavoriteNotReady(AppLocalizations loc) {
+  void _showMessage(String message) {
+    if (!mounted) return;
     ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(loc.feature_not_ready)));
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _toggleFavorite(AppLocalizations loc) async {
+    if (_favoriteLoading) return;
+
+    final currentUser = ref.read(authServiceProvider).currentUser;
+    if (currentUser == null) {
+      _showMessage(loc.not_logged_in);
+      return;
+    }
+
+    if (_event.id.isEmpty) {
+      _showMessage(loc.load_failed);
+      return;
+    }
+
+    setState(() => _favoriteLoading = true);
+    final api = ref.read(apiServiceProvider);
+
+    try {
+      if (_isFavorite) {
+        await api.removeFavoriteEvent(currentUser.uid, _event.id);
+      } else {
+        await api.addFavoriteEvent(currentUser.uid, _event.id);
+      }
+
+      setState(() {
+        _isFavorite = !_isFavorite;
+        _event = _event.copyWith(isFavorite: _isFavorite);
+      });
+
+      ref.invalidate(userFavoritesProvider);
+      ref.invalidate(eventsProvider);
+
+      _showMessage(
+        _isFavorite ? loc.added_to_favorites : loc.removed_from_favorites,
+      );
+    } on ApiException catch (error) {
+      final message =
+          error.message.isNotEmpty ? error.message : loc.load_failed;
+      _showMessage(message);
+    } catch (_) {
+      _showMessage(loc.load_failed);
+    } finally {
+      if (mounted) {
+        setState(() => _favoriteLoading = false);
+      }
+    }
+  }
+
+  Future<void> _toggleFollow(AppLocalizations loc) async {
+    if (_followLoading) return;
+
+    final organizer = _event.organizer;
+    if (organizer == null || organizer.id.isEmpty) {
+      _showMessage(loc.load_failed);
+      return;
+    }
+
+    final currentUser = ref.read(authServiceProvider).currentUser;
+    if (currentUser == null) {
+      _showMessage(loc.not_logged_in);
+      return;
+    }
+
+    setState(() => _followLoading = true);
+    final api = ref.read(apiServiceProvider);
+
+    try {
+      if (_isFollowing) {
+        await api.unfollowUser(organizer.id);
+      } else {
+        await api.followUser(organizer.id);
+      }
+
+      setState(() {
+        _isFollowing = !_isFollowing;
+        _event = _event.copyWith(
+          organizer: organizer.copyWith(isFollowed: _isFollowing),
+        );
+      });
+
+      _showMessage(_isFollowing ? loc.followed : loc.unfollowed);
+    } on ApiException catch (error) {
+      final message =
+          error.message.isNotEmpty ? error.message : loc.load_failed;
+      _showMessage(message);
+    } catch (_) {
+      _showMessage(loc.load_failed);
+    } finally {
+      if (mounted) {
+        setState(() => _followLoading = false);
+      }
+    }
+  }
+
+  void _popWithResult() {
+    Navigator.pop(context, _event);
   }
 
   @override
@@ -157,7 +274,7 @@ class _EventDetailPageState extends State<EventDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final event = widget.event;
+    final event = _event;
     final loc = AppLocalizations.of(context)!;
     final organizer = event.organizer;
     final hostName = (organizer?.name.isNotEmpty ?? false)
@@ -169,51 +286,53 @@ class _EventDetailPageState extends State<EventDetailPage> {
     final hostAvatar = (organizer?.avatarUrl?.isNotEmpty ?? false)
         ? organizer!.avatarUrl!
         : _fallbackHost.avatar;
-    return Scaffold(
-      backgroundColor: const Color(0xFFFFF7E9),
-      extendBodyBehindAppBar: true,
-      appBar: EventDetailAppBar(
-        loc: loc,
-        onBack: () => Navigator.pop(context),
-        onShare: () => _showShareSheet(context),
-        onFavorite: () => _onFavoriteNotReady(loc),
-      ),
-      bottomNavigationBar: EventDetailBottomBar(
-        loc: loc,
-        isFavorite: event.isFavorite,
-        onFavorite: () => _onFavoriteNotReady(loc),
-        onRegister: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(loc.registration_not_implemented)),
-          );
-        },
-      ),
-      body: EventDetailBody(
-        event: event,
-        loc: loc,
-        pageController: _pageCtrl,
-        currentPage: _page,
-        onPageChanged: (index) => setState(() => _page = index),
-        hostName: hostName,
-        hostBio: hostBio,
-        hostAvatarUrl: hostAvatar,
-        onTapHostProfile: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => UserProfilePage()),
-          );
-        },
-        onToggleFollow: () async {
-          // TODO: integrate backend follow logic
-          setState(() => _following = !_following);
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(_following ? loc.followed : loc.unfollowed),
-            ),
-          );
-        },
-        isFollowing: _following,
-        onTapLocation: () => Navigator.pop(context, widget.event),
+    return WillPopScope(
+      onWillPop: () async {
+        _popWithResult();
+        return false;
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFFFF7E9),
+        extendBodyBehindAppBar: true,
+        appBar: EventDetailAppBar(
+          loc: loc,
+          onBack: _popWithResult,
+          onShare: () => _showShareSheet(context),
+          onFavorite: () => _toggleFavorite(loc),
+          isFavorite: _isFavorite,
+          isFavoriteLoading: _favoriteLoading,
+        ),
+        bottomNavigationBar: EventDetailBottomBar(
+          loc: loc,
+          isFavorite: _isFavorite,
+          onFavorite: () => _toggleFavorite(loc),
+          onRegister: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(loc.registration_not_implemented)),
+            );
+          },
+          isFavoriteLoading: _favoriteLoading,
+        ),
+        body: EventDetailBody(
+          event: event,
+          loc: loc,
+          pageController: _pageCtrl,
+          currentPage: _page,
+          onPageChanged: (index) => setState(() => _page = index),
+          hostName: hostName,
+          hostBio: hostBio,
+          hostAvatarUrl: hostAvatar,
+          onTapHostProfile: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => UserProfilePage()),
+            );
+          },
+          onToggleFollow: () => _toggleFollow(loc),
+          isFollowing: _isFollowing,
+          onTapLocation: () => _popWithResult(),
+          followActionInProgress: _followLoading,
+        ),
       ),
     );
   }

--- a/lib/features/events/presentation/detail/widgets/event_detail_app_bar.dart
+++ b/lib/features/events/presentation/detail/widgets/event_detail_app_bar.dart
@@ -7,6 +7,8 @@ class EventDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback onBack;
   final VoidCallback onShare;
   final VoidCallback onFavorite;
+  final bool isFavorite;
+  final bool isFavoriteLoading;
 
   const EventDetailAppBar({
     super.key,
@@ -14,6 +16,8 @@ class EventDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.onBack,
     required this.onShare,
     required this.onFavorite,
+    required this.isFavorite,
+    required this.isFavoriteLoading,
   });
 
   @override
@@ -35,8 +39,17 @@ class EventDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
           onPressed: onShare,
         ),
         IconButton(
-          icon: const Icon(Icons.favorite_border, color: Colors.black),
-          onPressed: onFavorite,
+          icon: isFavoriteLoading
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Icon(
+                  isFavorite ? Icons.favorite : Icons.favorite_border,
+                  color: isFavorite ? Colors.redAccent : Colors.black,
+                ),
+          onPressed: isFavoriteLoading ? null : onFavorite,
         ),
         const SizedBox(width: 8),
       ],

--- a/lib/features/events/presentation/detail/widgets/event_detail_body.dart
+++ b/lib/features/events/presentation/detail/widgets/event_detail_body.dart
@@ -19,6 +19,7 @@ class EventDetailBody extends StatelessWidget {
   final VoidCallback onToggleFollow;
   final bool isFollowing;
   final VoidCallback onTapLocation;
+  final bool followActionInProgress;
 
   const EventDetailBody({
     super.key,
@@ -34,6 +35,7 @@ class EventDetailBody extends StatelessWidget {
     required this.onToggleFollow,
     required this.isFollowing,
     required this.onTapLocation,
+    this.followActionInProgress = false,
   });
 
   @override
@@ -57,6 +59,7 @@ class EventDetailBody extends StatelessWidget {
             onTapProfile: onTapHostProfile,
             onToggleFollow: onToggleFollow,
             isFollowing: isFollowing,
+            isProcessing: followActionInProgress,
           ),
           const SizedBox(height: 10),
           SizedBox(

--- a/lib/features/events/presentation/detail/widgets/event_detail_bottom_bar.dart
+++ b/lib/features/events/presentation/detail/widgets/event_detail_bottom_bar.dart
@@ -6,6 +6,7 @@ class EventDetailBottomBar extends StatelessWidget {
   final bool isFavorite;
   final VoidCallback onFavorite;
   final VoidCallback onRegister;
+  final bool isFavoriteLoading;
 
   const EventDetailBottomBar({
     super.key,
@@ -13,6 +14,7 @@ class EventDetailBottomBar extends StatelessWidget {
     required this.isFavorite,
     required this.onFavorite,
     required this.onRegister,
+    this.isFavoriteLoading = false,
   });
 
   @override
@@ -24,8 +26,17 @@ class EventDetailBottomBar extends StatelessWidget {
         child: Row(
           children: [
             IconButton(
-              icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
-              onPressed: onFavorite,
+              icon: isFavoriteLoading
+                  ? const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      isFavorite ? Icons.favorite : Icons.favorite_border,
+                      color: isFavorite ? Colors.redAccent : null,
+                    ),
+              onPressed: isFavoriteLoading ? null : onFavorite,
             ),
             const SizedBox(width: 12),
             Expanded(

--- a/lib/features/events/presentation/detail/widgets/event_host_card.dart
+++ b/lib/features/events/presentation/detail/widgets/event_host_card.dart
@@ -10,6 +10,7 @@ class EventHostCard extends StatelessWidget {
   final VoidCallback onTapProfile;
   final VoidCallback onToggleFollow;
   final bool isFollowing;
+  final bool isProcessing;
 
   const EventHostCard({
     super.key,
@@ -20,6 +21,7 @@ class EventHostCard extends StatelessWidget {
     required this.onTapProfile,
     required this.onToggleFollow,
     required this.isFollowing,
+    this.isProcessing = false,
   });
 
   @override
@@ -76,7 +78,7 @@ class EventHostCard extends StatelessWidget {
                 height: 36,
                 child: isFollowing
                     ? OutlinedButton.icon(
-                        onPressed: onToggleFollow,
+                        onPressed: isProcessing ? null : onToggleFollow,
                         style: OutlinedButton.styleFrom(
                           foregroundColor: Colors.orange,
                           side: BorderSide(color: Colors.orange.shade300),
@@ -84,11 +86,18 @@ class EventHostCard extends StatelessWidget {
                             borderRadius: BorderRadius.circular(10),
                           ),
                         ),
-                        icon: const Icon(Icons.check, size: 18),
+                        icon: isProcessing
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.check, size: 18),
                         label: Text(loc.action_following),
                       )
                     : ElevatedButton.icon(
-                        onPressed: onToggleFollow,
+                        onPressed: isProcessing ? null : onToggleFollow,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: Colors.orange,
                           foregroundColor: Colors.white,
@@ -96,7 +105,14 @@ class EventHostCard extends StatelessWidget {
                             borderRadius: BorderRadius.circular(10),
                           ),
                         ),
-                        icon: const Icon(Icons.person_add_alt_1, size: 18),
+                        icon: isProcessing
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.person_add_alt_1, size: 18),
                         label: Text(loc.action_follow),
                       ),
               ),

--- a/lib/features/profile/data/favorites_provider.dart
+++ b/lib/features/profile/data/favorites_provider.dart
@@ -1,0 +1,15 @@
+import 'package:crew_app/core/state/auth/auth_providers.dart';
+import 'package:crew_app/core/state/di/providers.dart';
+import 'package:crew_app/features/events/data/event.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final userFavoritesProvider =
+    FutureProvider.autoDispose<List<Event>>((ref) async {
+  final user = ref.watch(currentUserProvider);
+  if (user == null) {
+    return const [];
+  }
+
+  final api = ref.watch(apiServiceProvider);
+  return api.getUserFavorites(user.uid);
+});

--- a/lib/features/profile/presentation/favorites/favorites_page.dart
+++ b/lib/features/profile/presentation/favorites/favorites_page.dart
@@ -1,58 +1,181 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:crew_app/core/error/api_exception.dart';
+import 'package:crew_app/core/state/auth/auth_providers.dart';
+import 'package:crew_app/features/events/data/event.dart';
+import 'package:crew_app/features/events/presentation/detail/events_detail_page.dart';
+import 'package:crew_app/features/profile/data/favorites_provider.dart';
+import 'package:crew_app/features/events/presentation/widgets/event_image_placeholder.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-// 收藏 Provider
-final favoritesProvider = Provider<List<String>>((ref) => [
-      "Favorite 1",
-      "Favorite 2",
-      "Favorite 3",
-    ]);
 
 class FavoritesPage extends ConsumerWidget {
   const FavoritesPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final favorites = ref.watch(favoritesProvider);
-final loc = AppLocalizations.of(context)!;
+    final loc = AppLocalizations.of(context)!;
+    final currentUser = ref.watch(currentUserProvider);
+    final favoritesAsync = ref.watch(userFavoritesProvider);
 
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.favorites_title),
       ),
-      body: favorites.isEmpty
-           ? Center(child: Text(loc.favorites_empty))
-          : GridView.builder(
-              padding: const EdgeInsets.all(12),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 2,
-                crossAxisSpacing: 12,
-                mainAxisSpacing: 12,
-                childAspectRatio: 3 / 2,
+      body: currentUser == null
+          ? _CenteredScrollable(child: Text(loc.not_logged_in))
+          : favoritesAsync.when(
+              data: (favorites) => RefreshIndicator(
+                onRefresh: () => ref.refresh(userFavoritesProvider.future),
+                child: favorites.isEmpty
+                    ? _CenteredScrollable(child: Text(loc.favorites_empty))
+                    : ListView.separated(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                        itemCount: favorites.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 12),
+                        itemBuilder: (context, index) {
+                          final event = favorites[index];
+                          return _FavoriteEventTile(event: event);
+                        },
+                      ),
               ),
-              itemCount: favorites.length,
-              itemBuilder: (context, index) {
-                final item = favorites[index];
-                return Card(
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  elevation: 2,
-                  child: InkWell(
-                    onTap: () {
-                      // TODO: 点击查看详情
-                      ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(content: Text(loc.feature_not_ready)),
-                      );
-                    },
-                    child: Center(
-                      child: Text(item),
-                    ),
-                  ),
-                );
-              },
+              loading: () =>
+                  const _CenteredScrollable(child: CircularProgressIndicator()),
+              error: (error, _) =>
+                  _CenteredScrollable(child: Text(_errorMessage(error, loc))),
             ),
+    );
+  }
+}
+
+String _errorMessage(Object error, AppLocalizations loc) {
+  if (error is ApiException) {
+    return error.message.isNotEmpty ? error.message : loc.load_failed;
+  }
+  final message = error.toString();
+  return message.isEmpty ? loc.load_failed : message;
+}
+
+class _FavoriteEventTile extends StatelessWidget {
+  const _FavoriteEventTile({required this.event});
+
+  final Event event;
+
+  @override
+  Widget build(BuildContext context) {
+    final imageUrl = event.firstAvailableImageUrl;
+    final theme = Theme.of(context);
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      elevation: 3,
+      child: InkWell(
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => EventDetailPage(event: event)),
+        ),
+        child: SizedBox(
+          height: 140,
+          child: Row(
+            children: [
+              Expanded(
+                flex: 2,
+                child: imageUrl != null
+                    ? CachedNetworkImage(
+                        imageUrl: imageUrl,
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                        height: double.infinity,
+                        placeholder: (_, __) => const Center(
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                        errorWidget: (_, __, ___) =>
+                            const EventImagePlaceholder(aspectRatio: 4 / 3),
+                      )
+                    : const EventImagePlaceholder(aspectRatio: 4 / 3),
+              ),
+              Expanded(
+                flex: 3,
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        event.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      if (event.location.isNotEmpty)
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            const Icon(Icons.place_outlined,
+                                size: 16, color: Colors.orange),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(
+                                event.location,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                            ),
+                          ],
+                        ),
+                      if (event.startTime != null) ...[
+                        const SizedBox(height: 6),
+                        Row(
+                          children: [
+                            const Icon(Icons.event_outlined,
+                                size: 16, color: Colors.orange),
+                            const SizedBox(width: 6),
+                            Text(
+                              _formatDate(event.startTime!),
+                              style: theme.textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final local = date.toLocal();
+    return '${local.year}-${local.month.toString().padLeft(2, '0')}-${local.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class _CenteredScrollable extends StatelessWidget {
+  const _CenteredScrollable({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            SizedBox(
+              height: constraints.maxHeight,
+              child: Center(child: child),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/user/data/user_follow_summary.dart
+++ b/lib/features/user/data/user_follow_summary.dart
@@ -1,0 +1,52 @@
+class UserFollowSummary {
+  final String uid;
+  final String userName;
+  final String displayName;
+  final String avatarUrl;
+  final DateTime followedAt;
+
+  const UserFollowSummary({
+    required this.uid,
+    required this.userName,
+    required this.displayName,
+    required this.avatarUrl,
+    required this.followedAt,
+  });
+
+  factory UserFollowSummary.fromJson(Map<String, dynamic> json) {
+    String _asString(dynamic value) => value?.toString() ?? '';
+    DateTime _parseDate(dynamic value) {
+      if (value is DateTime) {
+        return value.toUtc();
+      }
+      if (value is String && value.isNotEmpty) {
+        final parsed = DateTime.tryParse(value);
+        if (parsed != null) {
+          return parsed.toUtc();
+        }
+      }
+      if (value is int) {
+        return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+      }
+      return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    }
+
+    return UserFollowSummary(
+      uid: _asString(json['uid'] ?? json['userId'] ?? json['id']),
+      userName: _asString(json['userName'] ?? json['username'] ?? json['name']),
+      displayName:
+          _asString(json['displayName'] ?? json['nickname'] ?? json['name']),
+      avatarUrl: _asString(
+        json['avatarUrl'] ??
+            json['avatar'] ??
+            json['photoUrl'] ??
+            json['imageUrl'] ??
+            json['profileImage'] ??
+            '',
+      ),
+      followedAt: _parseDate(
+        json['followedAt'] ?? json['createdAt'] ?? json['timestamp'],
+      ),
+    );
+  }
+}

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -440,6 +440,18 @@ abstract class AppLocalizations {
   /// **'Favorites'**
   String get favorites_title;
 
+  /// No description provided for @added_to_favorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Added to favorites'**
+  String get added_to_favorites;
+
+  /// No description provided for @removed_from_favorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Removed from favorites'**
+  String get removed_from_favorites;
+
   /// No description provided for @history_empty.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -185,6 +185,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get favorites_title => 'Favorites';
 
   @override
+  String get added_to_favorites => 'Added to favorites';
+
+  @override
+  String get removed_from_favorites => 'Removed from favorites';
+
+  @override
   String get history_empty => 'No history yet~';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -184,6 +184,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get favorites_title => '收藏';
 
   @override
+  String get added_to_favorites => '已添加到收藏';
+
+  @override
+  String get removed_from_favorites => '已从收藏移除';
+
+  @override
   String get history_empty => '暂无历史记录~';
 
   @override

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -67,6 +67,8 @@
   "followed": "Followed",
   "favorites_empty": "No favorites yet~",
   "favorites_title": "Favorites",
+  "added_to_favorites": "Added to favorites",
+  "removed_from_favorites": "Removed from favorites",
   "history_empty": "No history yet~",
   "history_title": "History",
   "industry_label_optional": "Industry (optional)",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -109,6 +109,8 @@
   "followed": "已关注",
   "favorites_empty": "暂无收藏~",
   "favorites_title": "收藏",
+  "added_to_favorites": "已添加到收藏",
+  "removed_from_favorites": "已从收藏移除",
   "history_empty": "暂无历史记录~",
   "history_title": "历史记录",
   "industry_label_optional": "行业（选填）",


### PR DESCRIPTION
## Summary
- connect the API service to new follow/favorite endpoints and expose a reusable follow summary DTO
- allow the event detail page to toggle follow state and favorites against the backend while updating related providers
- replace the placeholder favorites screen with a backend-driven Riverpod provider, cards, and new localization strings

## Testing
- Unable to run tests (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ae5ce098832cb18e3925b07bcdd0