### PR TITLE
Move browsing history and verification links into settings

### DIFF
--- a/lib/features/profile/presentation/profile/profile_page.dart
+++ b/lib/features/profile/presentation/profile/profile_page.dart
@@ -77,20 +77,6 @@ class ProfilePage extends ConsumerWidget {
                   ),
                   const Divider(height: 1),
                   ListTile(
-                    leading: const Icon(Icons.history),
-                    title: Text(loc.browsing_history),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () => Navigator.pushNamed(context, '/history'),
-                  ),
-                  const Divider(height: 1),
-                  ListTile(
-                    leading: const Icon(Icons.verified_user),
-                    title: Text(loc.verification_preferences),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () => Navigator.pushNamed(context, '/preferences'),
-                  ),
-                  const Divider(height: 1),
-                  ListTile(
                     leading: const Icon(Icons.settings_outlined),
                     title: Text(loc.settings),
                     trailing: const Icon(Icons.chevron_right),

--- a/lib/features/settings/presentation/settings/settings_page.dart
+++ b/lib/features/settings/presentation/settings/settings_page.dart
@@ -212,6 +212,18 @@ class SettingsPage extends ConsumerWidget {
                 ),
               ),
               ListTile(
+                leading: const Icon(Icons.history),
+                title: Text(loc.browsing_history),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => Navigator.pushNamed(context, '/history'),
+              ),
+              ListTile(
+                leading: const Icon(Icons.verified_user),
+                title: Text(loc.verification_preferences),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => Navigator.pushNamed(context, '/preferences'),
+              ),
+              ListTile(
                 leading: const Icon(Icons.logout),
                 title: Text(loc.action_logout),
                 onTap: () {


### PR DESCRIPTION
## Summary
- remove browsing history and verification preference shortcuts from the profile page quick actions
- add browsing history and verification preference entries to the account section of the settings page so they live under settings

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f47c392c832c98c84a06ad156e21