### PR TITLE
refactor: extract shared masonry grid and share sheet

### DIFF
--- a/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
+++ b/lib/features/events/presentation/detail/widgets/event_share_sheet.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:crew_app/features/events/data/event.dart';
 import 'package:crew_app/features/events/presentation/widgets/event_image_placeholder.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
+import 'package:crew_app/shared/widgets/share/app_share_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -27,54 +28,38 @@ class EventShareSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bottomPadding = MediaQuery.of(context).padding.bottom;
     final theme = Theme.of(context);
-    return SafeArea(
-      top: false,
-      child: Align(
-        alignment: Alignment.bottomCenter,
-        child: Padding(
-          padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPadding + 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SharePreviewCard(
-                event: event,
-                loc: loc,
-                previewKey: previewKey,
-                shareLink: shareLink,
-              ),
-              const SizedBox(height: 20),
-              Text(
-                loc.share_card_subtitle,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: Colors.black54,
-                  height: 1.4,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 16,
-                runSpacing: 12,
-                children: [
-                  ShareActionButton(
-                    icon: Icons.image_outlined,
-                    label: loc.share_action_save_image,
-                    onTap: onSaveImage,
-                  ),
-                  ShareActionButton(
-                    icon: Icons.ios_share,
-                    label: loc.share_action_share_system,
-                    onTap: onShareSystem,
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
+    return AppShareSheet(
+      preview: SharePreviewCard(
+        event: event,
+        loc: loc,
+        previewKey: previewKey,
+        shareLink: shareLink,
       ),
+      description: Text(
+        loc.share_card_subtitle,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: Colors.black54,
+          height: 1.4,
+        ),
+        textAlign: TextAlign.center,
+      ),
+      actions: [
+        AppShareActionButton(
+          icon: Icons.image_outlined,
+          label: loc.share_action_save_image,
+          onTap: onSaveImage,
+          iconColor: Colors.orange,
+          labelColor: Colors.orange.shade800,
+        ),
+        AppShareActionButton(
+          icon: Icons.ios_share,
+          label: loc.share_action_share_system,
+          onTap: onShareSystem,
+          iconColor: Colors.orange,
+          labelColor: Colors.orange.shade800,
+        ),
+      ],
     );
   }
 }
@@ -416,46 +401,3 @@ class _SharePreviewImage extends StatelessWidget {
   }
 }
 
-
-class ShareActionButton extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final Future<void> Function() onTap;
-
-  const ShareActionButton({
-    super.key,
-    required this.icon,
-    required this.label,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Material(
-      color: Colors.white,
-      borderRadius: BorderRadius.circular(16),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(16),
-        onTap: () => onTap(),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, color: Colors.orange),
-              const SizedBox(width: 10),
-              Text(
-                label,
-                style: theme.textTheme.labelLarge?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: Colors.orange.shade800,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/events/presentation/list/events_list_page.dart
+++ b/lib/features/events/presentation/list/events_list_page.dart
@@ -4,7 +4,7 @@ import 'package:crew_app/features/events/presentation/widgets/event_image_placeh
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:crew_app/shared/widgets/app_masonry_grid.dart';
 
 import '../../../../core/state/app/app_overlay_provider.dart';
 import '../../../../core/error/api_exception.dart';
@@ -47,7 +47,7 @@ class _EventsListPageState extends ConsumerState<EventsListPage> {
               return _CenteredScrollable(child: Text(loc.no_events));
             }
 
-            return MasonryGridView.count(
+            return AppMasonryGrid(
               padding: const EdgeInsets.all(8),
               crossAxisCount: 2,
               mainAxisSpacing: 8,

--- a/lib/shared/widgets/app_masonry_grid.dart
+++ b/lib/shared/widgets/app_masonry_grid.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+
+/// A reusable wrapper around [MasonryGridView] with sensible defaults used
+/// across the app for waterfall-style layouts.
+class AppMasonryGrid extends StatelessWidget {
+  const AppMasonryGrid({
+    super.key,
+    required this.itemCount,
+    required this.itemBuilder,
+    this.crossAxisCount = 2,
+    this.mainAxisSpacing = 8,
+    this.crossAxisSpacing = 8,
+    this.padding,
+    this.physics,
+    this.shrinkWrap = false,
+  });
+
+  final int itemCount;
+  final IndexedWidgetBuilder itemBuilder;
+  final int crossAxisCount;
+  final double mainAxisSpacing;
+  final double crossAxisSpacing;
+  final EdgeInsetsGeometry? padding;
+  final ScrollPhysics? physics;
+  final bool shrinkWrap;
+
+  @override
+  Widget build(BuildContext context) {
+    return MasonryGridView.count(
+      padding: padding,
+      crossAxisCount: crossAxisCount,
+      mainAxisSpacing: mainAxisSpacing,
+      crossAxisSpacing: crossAxisSpacing,
+      itemCount: itemCount,
+      physics: physics,
+      shrinkWrap: shrinkWrap,
+      itemBuilder: itemBuilder,
+    );
+  }
+}

--- a/lib/shared/widgets/share/app_share_sheet.dart
+++ b/lib/shared/widgets/share/app_share_sheet.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+/// A reusable bottom sheet layout for sharing content with preview and actions.
+class AppShareSheet extends StatelessWidget {
+  const AppShareSheet({
+    super.key,
+    required this.preview,
+    required this.actions,
+    this.description,
+    this.actionSpacing = 16,
+    this.actionRunSpacing = 12,
+  });
+
+  final Widget preview;
+  final Widget? description;
+  final List<Widget> actions;
+  final double actionSpacing;
+  final double actionRunSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
+    return SafeArea(
+      top: false,
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPadding + 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              preview,
+              if (description != null) ...[
+                const SizedBox(height: 20),
+                description!,
+              ],
+              const SizedBox(height: 24),
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: actionSpacing,
+                runSpacing: actionRunSpacing,
+                children: actions,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class AppShareActionButton extends StatelessWidget {
+  const AppShareActionButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.backgroundColor = Colors.white,
+    this.iconColor = Colors.orange,
+    this.labelColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final Future<void> Function() onTap;
+  final Color backgroundColor;
+  final Color iconColor;
+  final Color? labelColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: () => onTap(),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: iconColor),
+              const SizedBox(width: 10),
+              Text(
+                label,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: labelColor ?? iconColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create a reusable `AppMasonryGrid` widget for waterfall layouts
- add shared share sheet and action button components
- update the events list and share sheet to use the new shared widgets

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e4fa9822d0832c8b5b4ebc5716727e