### PR TITLE
Refine map overlays with draggable bottom sheets

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,13 +2,14 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:crew_app/features/chat/user_event/presentation/user_events_page.dart';
+import 'package:crew_app/features/events/presentation/list/events_list_page.dart';
+import 'package:crew_app/features/events/presentation/map/events_map_page.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:crew_app/shared/widgets/scroll_activity_listener.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../features/events/presentation/list/events_list_page.dart';
-import '../features/events/presentation/map/events_map_page.dart';
 import '../core/state/app/app_overlay_provider.dart';
 
 class App extends ConsumerStatefulWidget {
@@ -18,42 +19,110 @@ class App extends ConsumerStatefulWidget {
 }
 
 class _AppState extends ConsumerState<App> {
+  static const _sheetSnapSizes = [0.18, 0.42, 0.9];
+  static const _sheetAnimationDuration = Duration(milliseconds: 280);
+
   int _index = 1; // 默认打开“地图”
   bool _isScrolling = false;
   Timer? _scrollDebounceTimer;
-  late final PageController _overlayController = PageController(initialPage: 1);
-  ProviderSubscription<int>? _overlayIndexSubscription;
+  double _sheetExtent = 0.0;
+
+  late final DraggableScrollableController _sheetController;
+  ProviderSubscription<int>? _navIndexSubscription;
 
   @override
   void initState() {
     super.initState();
-    _overlayIndexSubscription = ref.listenManual(
+    _sheetController = DraggableScrollableController();
+    _sheetController.addListener(_handleSheetExtentChanged);
+    _navIndexSubscription = ref.listenManual(
       appOverlayIndexProvider,
-      (previous, next) {
-        if (next == _index) {
-          return;
-        }
-        setState(() {
-          _index = next;
-          if (next == 1) {
-            _isScrolling = false;
-          }
-        });
-        _overlayController.animateToPage(
-          next,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeInOut,
-        );
-      },
+      (previous, next) => _onNavIndexChanged(next),
     );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _onNavIndexChanged(ref.read(appOverlayIndexProvider));
+    });
   }
 
   @override
   void dispose() {
-    _overlayController.dispose();
+    _navIndexSubscription?.close();
+    _sheetController.removeListener(_handleSheetExtentChanged);
+    _sheetController.dispose();
     _scrollDebounceTimer?.cancel();
-    _overlayIndexSubscription?.close();
     super.dispose();
+  }
+
+  void _onNavIndexChanged(int next) {
+    if (!mounted) {
+      return;
+    }
+    if (_index == next) {
+      if (next != 1) {
+        _expandSheet();
+      }
+      return;
+    }
+    setState(() {
+      _index = next;
+      if (next == 1) {
+        _isScrolling = false;
+      }
+    });
+    if (next == 1) {
+      _collapseSheet();
+    } else {
+      _expandSheet();
+    }
+  }
+
+  void _handleSheetExtentChanged() {
+    if (!mounted || !_sheetController.isAttached) {
+      return;
+    }
+    final size = _sheetController.size;
+    if ((size - _sheetExtent).abs() < 0.0005) {
+      return;
+    }
+    setState(() {
+      _sheetExtent = size;
+      if (size <= 0.001 && _index != 1) {
+        _index = 1;
+        _isScrolling = false;
+        ref.read(appOverlayIndexProvider.notifier).state = 1;
+      }
+    });
+  }
+
+  void _expandSheet() {
+    if (!_sheetController.isAttached) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _expandSheet());
+      return;
+    }
+    final target = _sheetController.size <= 0.0
+        ? _sheetSnapSizes[1]
+        : _sheetController.size
+            .clamp(_sheetSnapSizes.first, _sheetSnapSizes.last);
+    _sheetController.animateTo(
+      target,
+      duration: _sheetAnimationDuration,
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _collapseSheet() {
+    if (!_sheetController.isAttached) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _collapseSheet());
+      return;
+    }
+    _sheetController.animateTo(
+      0.0,
+      duration: _sheetAnimationDuration,
+      curve: Curves.easeInOut,
+    );
   }
 
   void _handleScrollActivity(bool scrolling) {
@@ -119,8 +188,6 @@ class _AppState extends ConsumerState<App> {
       ),
     ];
 
-    final isOverlayOpen = _index != 1;
-
     return Scaffold(
       extendBody: true,
       body: Stack(
@@ -130,38 +197,41 @@ class _AppState extends ConsumerState<App> {
             listenToPointerActivity: true,
             child: const EventsMapPage(),
           ),
-          IgnorePointer(
-            ignoring: !isOverlayOpen,
-            child: PageView(
-              controller: _overlayController,
-              physics: isOverlayOpen
-                  ? const PageScrollPhysics()
-                  : const NeverScrollableScrollPhysics(),
-              onPageChanged: (page) {
-                final shouldUpdateIndex = _index != page;
-                final shouldResetScroll = page == 1 && _isScrolling;
-                if (!shouldUpdateIndex && !shouldResetScroll) {
-                  return;
-                }
-                setState(() {
-                  _index = page;
-                  if (page == 1) {
-                    _isScrolling = false;
-                  }
-                });
-                ref.read(appOverlayIndexProvider.notifier).state = page;
-              },
-              children: [
-                ScrollActivityListener(
-                  onScrollActivityChanged: _handleScrollActivity,
-                  child: const EventsListPage(),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: IgnorePointer(
+              ignoring: _sheetExtent <= 0.001,
+              child: AnimatedOpacity(
+                opacity: _sheetExtent <= 0.001 ? 0 : 1,
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                child: DraggableScrollableSheet(
+                  controller: _sheetController,
+                  snap: true,
+                  minChildSize: 0.0,
+                  maxChildSize: _sheetSnapSizes.last,
+                  initialChildSize: 0.0,
+                  snapSizes: _sheetSnapSizes,
+                  builder: (context, scrollController) {
+                    final bottomPadding =
+                        MediaQuery.of(context).viewPadding.bottom;
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        left: 12,
+                        right: 12,
+                        bottom: 12 + bottomPadding,
+                      ),
+                      child: _SheetContainer(
+                        child: _buildSheetContent(
+                          context,
+                          loc,
+                          scrollController,
+                        ),
+                      ),
+                    );
+                  },
                 ),
-                const SizedBox.expand(),
-                ScrollActivityListener(
-                  onScrollActivityChanged: _handleScrollActivity,
-                  child: const UserEventsPage(),
-                ),
-              ],
+              ),
             ),
           ),
         ],
@@ -220,6 +290,9 @@ class _AppState extends ConsumerState<App> {
                       selectedIndex: _index,
                       onDestinationSelected: (i) {
                         if (_index == i) {
+                          if (i != 1) {
+                            _expandSheet();
+                          }
                           return;
                         }
                         setState(() {
@@ -229,11 +302,11 @@ class _AppState extends ConsumerState<App> {
                           }
                         });
                         ref.read(appOverlayIndexProvider.notifier).state = i;
-                        _overlayController.animateToPage(
-                          i,
-                          duration: const Duration(milliseconds: 300),
-                          curve: Curves.easeInOut,
-                        );
+                        if (i == 1) {
+                          _collapseSheet();
+                        } else {
+                          _expandSheet();
+                        }
                       },
                       destinations: destinations,
                     ),
@@ -246,4 +319,107 @@ class _AppState extends ConsumerState<App> {
       ),
     );
   }
+
+  Widget _buildSheetContent(
+    BuildContext context,
+    AppLocalizations loc,
+    ScrollController scrollController,
+  ) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final title = _index == 0 ? loc.events_title : loc.my_events;
+    final body = _index == 0
+        ? EventsListPage(
+            useScaffold: false,
+            scrollController: scrollController,
+            contentPadding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+          )
+        : UserEventsPage(
+            useScaffold: false,
+            scrollController: scrollController,
+          );
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withValues(alpha: 0.14),
+            blurRadius: 32,
+            offset: const Offset(0, 18),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Container(
+              width: 44,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.28),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 12, 12),
+              child: Row(
+                children: [
+                  Text(
+                    title,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                    icon: const Icon(Icons.close),
+                    onPressed: () {
+                      ref.read(appOverlayIndexProvider.notifier).state = 1;
+                      _collapseSheet();
+                    },
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: NotificationListener<UserScrollNotification>(
+                onNotification: (notification) {
+                  final scrolling =
+                      notification.direction != ScrollDirection.idle;
+                  _handleScrollActivity(scrolling);
+                  return false;
+                },
+                child: body,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
+
+class _SheetContainer extends StatelessWidget {
+  const _SheetContainer({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(28),
+          child: child,
+        );
+      },
+    );
+  }
+}
+

--- a/lib/features/chat/user_event/presentation/widgets/user_events_favorites_grid.dart
+++ b/lib/features/chat/user_event/presentation/widgets/user_events_favorites_grid.dart
@@ -11,17 +11,24 @@ class UserEventsFavoritesGrid extends StatelessWidget {
     super.key,
     required this.events,
     this.onEventTap,
+    this.controller,
+    this.physics,
   });
 
   final List<UserEventPreview> events;
   final UserEventTap? onEventTap;
+  final ScrollController? controller;
+  final ScrollPhysics? physics;
 
   @override
   Widget build(BuildContext context) {
     return MasonryGridView.count(
       key: const PageStorageKey('user-events-favorites-grid'),
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-      physics: const BouncingScrollPhysics(),
+      controller: controller,
+      physics:
+          physics ?? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+      primary: controller == null,
       crossAxisCount: 2,
       mainAxisSpacing: 16,
       crossAxisSpacing: 16,

--- a/lib/features/chat/user_event/presentation/widgets/user_events_registered_list.dart
+++ b/lib/features/chat/user_event/presentation/widgets/user_events_registered_list.dart
@@ -8,17 +8,23 @@ class UserEventsRegisteredList extends StatelessWidget {
     super.key,
     required this.events,
     this.onEventTap,
+    this.controller,
+    this.physics,
   });
 
   final List<UserEventPreview> events;
   final ValueChanged<int>? onEventTap;
+  final ScrollController? controller;
+  final ScrollPhysics? physics;
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       key: const PageStorageKey('user-events-registered-list'),
       padding: const EdgeInsets.only(bottom: 24),
-      physics: const BouncingScrollPhysics(),
+      controller: controller,
+      physics:
+          physics ?? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
       itemCount: events.length,
       itemBuilder: (context, index) {
         final event = events[index];

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:crew_app/features/profile/presentation/profile/profile_page.dart';
 
 import '../../data/event.dart';
 import '../../data/event_filter.dart';
@@ -247,11 +248,29 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
   }
 
   void _onAvatarTap(bool authed) {
-    if (authed) {
-      Navigator.pushNamed(context, '/profile');
-    } else {
-      Navigator.pushNamed(context, '/profile');
-    }
+    Navigator.of(context).push(_profilePageRoute());
+  }
+
+  PageRoute<void> _profilePageRoute() {
+    return PageRouteBuilder<void>(
+      pageBuilder: (_, __, ___) => const ProfilePage(),
+      transitionDuration: const Duration(milliseconds: 300),
+      reverseTransitionDuration: const Duration(milliseconds: 260),
+      transitionsBuilder: (_, animation, secondaryAnimation, child) {
+        final curved = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeOutCubic,
+          reverseCurve: Curves.easeInCubic,
+        );
+        return SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(1, 0),
+            end: Offset.zero,
+          ).animate(curved),
+          child: child,
+        );
+      },
+    );
   }
 
   Future<bool> _ensureDisclaimerAccepted() async {

--- a/lib/features/profile/presentation/profile/profile_page.dart
+++ b/lib/features/profile/presentation/profile/profile_page.dart
@@ -21,7 +21,7 @@ class ProfilePage extends ConsumerWidget {
     final profileState = ref.watch(authenticatedUserProvider);
     final backendUser = profileState.asData?.value;
 
-    return Scaffold(
+    final page = Scaffold(
       appBar: AppBar(
         title: Text(loc.profile_title),
         centerTitle: true,
@@ -89,6 +89,16 @@ class ProfilePage extends ConsumerWidget {
           ),
         ),
       ),
+    );
+    return Dismissible(
+      key: const ValueKey('profile_page_dismissible'),
+      direction: DismissDirection.startToEnd,
+      dismissThresholds: const {DismissDirection.startToEnd: 0.32},
+      background: const SizedBox.shrink(),
+      onDismissed: (_) {
+        Navigator.of(context).maybePop();
+      },
+      child: page,
     );
   }
 }

--- a/lib/shared/widgets/app_masonry_grid.dart
+++ b/lib/shared/widgets/app_masonry_grid.dart
@@ -14,6 +14,8 @@ class AppMasonryGrid extends StatelessWidget {
     this.padding,
     this.physics,
     this.shrinkWrap = false,
+    this.controller,
+    this.primary,
   });
 
   final int itemCount;
@@ -24,6 +26,8 @@ class AppMasonryGrid extends StatelessWidget {
   final EdgeInsetsGeometry? padding;
   final ScrollPhysics? physics;
   final bool shrinkWrap;
+  final ScrollController? controller;
+  final bool? primary;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +39,8 @@ class AppMasonryGrid extends StatelessWidget {
       itemCount: itemCount,
       physics: physics,
       shrinkWrap: shrinkWrap,
+      controller: controller,
+      primary: primary,
       itemBuilder: itemBuilder,
     );
   }


### PR DESCRIPTION
## Summary
- replace the events and group overlay pages with a persistent draggable bottom sheet on the map
- rework the app shell to drive the sheet and preserve navigation styling during scroll interactions
- update the profile route to slide in from the right and allow swipe-to-dismiss, sharing scroll controllers for sheet content

## Testing
- Not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e51c7e03e0832c9e230db9e6ebaaab