### PR TITLE
Add swipe-to-dismiss interaction to ProfilePage

### DIFF
--- a/lib/features/profile/presentation/profile/profile_page.dart
+++ b/lib/features/profile/presentation/profile/profile_page.dart
@@ -21,7 +21,7 @@ class ProfilePage extends ConsumerWidget {
     final profileState = ref.watch(authenticatedUserProvider);
     final backendUser = profileState.asData?.value;
 
-    return Scaffold(
+    final page = Scaffold(
       appBar: AppBar(
         title: Text(loc.profile_title),
         centerTitle: true,
@@ -89,6 +89,16 @@ class ProfilePage extends ConsumerWidget {
           ),
         ),
       ),
+    );
+    return Dismissible(
+      key: const ValueKey('profile_page_dismissible'),
+      direction: DismissDirection.startToEnd,
+      dismissThresholds: const {DismissDirection.startToEnd: 0.32},
+      background: const SizedBox.shrink(),
+      onDismissed: (_) {
+        Navigator.of(context).maybePop();
+      },
+      child: page,
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap the profile scaffold in a Dismissible so it can be swiped away from right to left
- keep all other map, events, and overlay pages at their previous implementations

## Testing
- Not run (Flutter SDK not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e51c7e03e0832c9e230db9e6ebaaab