### PR TITLE
feat: redesign overlays as draggable sheets

### DIFF
--- a/lib/features/events/presentation/events_list/events_list_page.dart
+++ b/lib/features/events/presentation/events_list/events_list_page.dart
@@ -3,26 +3,55 @@ import 'package:crew_app/features/events/presentation/widgets/event_grid_card.da
 import 'package:crew_app/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:crew_app/shared/widgets/app_masonry_grid.dart';
+import 'package:crew_app/shared/widgets/app_sheet_scaffold.dart';
 
 import '../../../../app/state/app_overlay_provider.dart';
 import '../../../../core/error/api_exception.dart';
 import 'package:crew_app/features/events/state/events_providers.dart';
 
 class EventsListPage extends ConsumerStatefulWidget {
-  const EventsListPage({super.key});
+  const EventsListPage({
+    super.key,
+    this.scrollController,
+    this.onClose,
+    this.showAsSheet = false,
+  });
+
+  final ScrollController? scrollController;
+  final VoidCallback? onClose;
+  final bool showAsSheet;
 
   @override
   ConsumerState<EventsListPage> createState() => _EventsListPageState();
 }
 
 class _EventsListPageState extends ConsumerState<EventsListPage> {
+  ScrollController? _internalController;
+
+  ScrollController get _controller =>
+      widget.scrollController ?? _internalController!;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.scrollController == null) {
+      _internalController = ScrollController();
+    }
+  }
+
+  @override
+  void dispose() {
+    _internalController?.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final eventsAsync = ref.watch(eventsProvider);
 
-    // 刷新列表
     ref.listen<AsyncValue<List<Event>>>(eventsProvider, (prev, next) {
       next.whenOrNull(error: (error, _) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -35,38 +64,60 @@ class _EventsListPageState extends ConsumerState<EventsListPage> {
       });
     });
 
-    return Scaffold(
-      appBar: AppBar(title: Text(loc.events_title)),
-      body: RefreshIndicator(
-        onRefresh: () async => await ref.refresh(eventsProvider.future),
-        child: eventsAsync.when(
-          data: (events) {
-            if (events.isEmpty) {
-              return _CenteredScrollable(child: Text(loc.no_events));
-            }
-
-            return AppMasonryGrid(
-              padding: const EdgeInsets.all(8),
-              crossAxisCount: 2,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
-              itemCount: events.length,
-              physics: const AlwaysScrollableScrollPhysics(),
-              itemBuilder: (context, i) => EventGridCard(
-                event: events[i],
-                heroTag: 'event_$i',
-                onShowOnMap: (event) {
-                  ref.read(appOverlayIndexProvider.notifier).state = 1;
-                  ref.read(mapFocusEventProvider.notifier).state = event;
-                },
-              ),
+    final body = RefreshIndicator(
+      onRefresh: () async => await ref.refresh(eventsProvider.future),
+      child: eventsAsync.when(
+        data: (events) {
+          if (events.isEmpty) {
+            return _CenteredScrollable(
+              controller: _controller,
+              child: Text(loc.no_events),
             );
-          },
-          loading: () =>
-              const _CenteredScrollable(child: CircularProgressIndicator()),
-          error: (_, _) => _CenteredScrollable(child: Text(loc.load_failed)),
+          }
+
+          return AppMasonryGrid(
+            controller: _controller,
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+            crossAxisCount: 2,
+            mainAxisSpacing: 12,
+            crossAxisSpacing: 12,
+            itemCount: events.length,
+            physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics(),
+            ),
+            itemBuilder: (context, i) => EventGridCard(
+              event: events[i],
+              heroTag: 'event_$i',
+              onShowOnMap: (event) {
+                ref.read(appOverlayIndexProvider.notifier).state = 1;
+                ref.read(mapFocusEventProvider.notifier).state = event;
+              },
+            ),
+          );
+        },
+        loading: () => _CenteredScrollable(
+          controller: _controller,
+          child: const CircularProgressIndicator(),
+        ),
+        error: (_, __) => _CenteredScrollable(
+          controller: _controller,
+          child: Text(loc.load_failed),
         ),
       ),
+    );
+
+    if (!widget.showAsSheet) {
+      return Scaffold(
+        appBar: AppBar(title: Text(loc.events_title)),
+        body: body,
+      );
+    }
+
+    return AppSheetScaffold(
+      title: loc.events_title,
+      controller: _controller,
+      onClose: widget.onClose,
+      child: body,
     );
   }
 }
@@ -80,16 +131,23 @@ String _errorMessage(Object error) {
 }
 
 class _CenteredScrollable extends StatelessWidget {
-  final Widget child;
+  const _CenteredScrollable({
+    required this.controller,
+    required this.child,
+  });
 
-  const _CenteredScrollable({required this.child});
+  final ScrollController controller;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
         return ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
+          controller: controller,
+          physics: const AlwaysScrollableScrollPhysics(
+            parent: BouncingScrollPhysics(),
+          ),
           children: [
             SizedBox(
               height: constraints.maxHeight,

--- a/lib/features/events/presentation/group_chat/widgets/group_chat_favorites_grid.dart
+++ b/lib/features/events/presentation/group_chat/widgets/group_chat_favorites_grid.dart
@@ -10,10 +10,12 @@ class GroupChatFavoritesGrid extends StatelessWidget {
     super.key,
     required this.events,
     this.onEventTap,
+    this.controller,
   });
 
   final List<GroupChatPreview> events;
   final GroupChatTap? onEventTap;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -21,6 +23,7 @@ class GroupChatFavoritesGrid extends StatelessWidget {
       key: const PageStorageKey('user-events-favorites-grid'),
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
       physics: const BouncingScrollPhysics(),
+      controller: controller,
       crossAxisCount: 2,
       mainAxisSpacing: 16,
       crossAxisSpacing: 16,

--- a/lib/features/events/presentation/group_chat/widgets/group_chat_registered_list.dart
+++ b/lib/features/events/presentation/group_chat/widgets/group_chat_registered_list.dart
@@ -7,10 +7,12 @@ class GroupChatRegisteredList extends StatelessWidget {
     super.key,
     required this.events,
     this.onEventTap,
+    this.controller,
   });
 
   final List<GroupChatPreview> events;
   final ValueChanged<int>? onEventTap;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -18,6 +20,7 @@ class GroupChatRegisteredList extends StatelessWidget {
       key: const PageStorageKey('user-events-registered-list'),
       padding: const EdgeInsets.only(bottom: 24),
       physics: const BouncingScrollPhysics(),
+      controller: controller,
       itemCount: events.length,
       itemBuilder: (context, index) {
         final event = events[index];

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -15,6 +15,7 @@ import '../../data/event_filter.dart';
 import '../../../../core/error/api_exception.dart';
 import '../../../../core/network/api_service.dart';
 import '../../../../core/state/di/providers.dart';
+import '../../../../app/state/app_overlay_provider.dart';
 import 'package:crew_app/features/events/state/events_providers.dart';
 import 'package:crew_app/features/events/state/user_location_provider.dart';
 import 'widgets/search_event_appbar.dart';
@@ -247,11 +248,7 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
   }
 
   void _onAvatarTap(bool authed) {
-    if (authed) {
-      Navigator.pushNamed(context, '/profile');
-    } else {
-      Navigator.pushNamed(context, '/profile');
-    }
+    ref.read(appOverlayIndexProvider.notifier).state = 3;
   }
 
   Future<bool> _ensureDisclaimerAccepted() async {

--- a/lib/shared/widgets/app_masonry_grid.dart
+++ b/lib/shared/widgets/app_masonry_grid.dart
@@ -14,6 +14,7 @@ class AppMasonryGrid extends StatelessWidget {
     this.padding,
     this.physics,
     this.shrinkWrap = false,
+    this.controller,
   });
 
   final int itemCount;
@@ -24,6 +25,7 @@ class AppMasonryGrid extends StatelessWidget {
   final EdgeInsetsGeometry? padding;
   final ScrollPhysics? physics;
   final bool shrinkWrap;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +37,7 @@ class AppMasonryGrid extends StatelessWidget {
       itemCount: itemCount,
       physics: physics,
       shrinkWrap: shrinkWrap,
+      controller: controller,
       itemBuilder: itemBuilder,
     );
   }

--- a/lib/shared/widgets/app_sheet_scaffold.dart
+++ b/lib/shared/widgets/app_sheet_scaffold.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+class AppSheetScaffold extends StatelessWidget {
+  const AppSheetScaffold({
+    super.key,
+    required this.title,
+    required this.controller,
+    required this.child,
+    this.actions,
+    this.leading,
+    this.onClose,
+  });
+
+  final String title;
+  final ScrollController controller;
+  final Widget child;
+  final List<Widget>? actions;
+  final Widget? leading;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final effectiveActions = <Widget>[...?actions];
+    if (onClose != null) {
+      effectiveActions.add(
+        IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+          onPressed: onClose,
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+      child: Material(
+        color: colorScheme.surface,
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 12),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colorScheme.onSurface.withValues(alpha: 0.18),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    if (leading != null) ...[
+                      leading!,
+                      const SizedBox(width: 12),
+                    ],
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    for (final action in effectiveActions) ...[
+                      const SizedBox(width: 8),
+                      action,
+                    ],
+                  ],
+                ),
+              ),
+              const Divider(height: 1),
+              Expanded(
+                child: PrimaryScrollController(
+                  controller: controller,
+                  child: child,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace the PageView overlay with a draggable bottom sheet that hosts events, group chat, and profile panes
- extract a reusable AppSheetScaffold and refactor the events list and group chat content to function within the new sheet layout
- reuse the profile content as a sheet and open it from the map avatar instead of routing to a new page

## Testing
- Not run (Flutter/Dart SDK not available in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68e586ddd1c8832c80043dc9366e79ae