### PR TITLE
Replace Flutter Map with Google Maps implementation

### DIFF
--- a/lib/features/events/presentation/map/sheets/map_create_event_sheet.dart
+++ b/lib/features/events/presentation/map/sheets/map_create_event_sheet.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'dart:typed_data';
 import 'package:image_picker/image_picker.dart';
 import 'package:geocoding/geocoding.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 class _CreateEventImage {
   _CreateEventImage({required this.file, required this.bytes});

--- a/lib/features/events/presentation/map/widgets/map_canvas.dart
+++ b/lib/features/events/presentation/map/widgets/map_canvas.dart
@@ -1,45 +1,45 @@
 // widgets/map_canvas.dart
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 /// 地图视图
 class MapCanvas extends StatelessWidget {
-  final MapController mapController;
   final LatLng initialCenter;
+  final double initialZoom;
+  final ValueChanged<GoogleMapController>? onMapCreated;
   final VoidCallback? onMapReady;
-  final void Function(TapPosition, LatLng)? onLongPress;
-  final List<Widget> children;
+  final ValueChanged<LatLng>? onLongPress;
+  final Set<Marker> markers;
 
   const MapCanvas({
     super.key,
-    required this.mapController,
     required this.initialCenter,
+    this.initialZoom = 5,
+    this.onMapCreated,
     this.onMapReady,
     this.onLongPress,
-    required this.children,
+    this.markers = const <Marker>{},
   });
 
   @override
   Widget build(BuildContext context) {
-    return FlutterMap(
-      mapController: mapController,
-      options: MapOptions(
-        initialCenter: initialCenter,
-        initialZoom: 5,
-        onMapReady: onMapReady,
-        onLongPress: onLongPress,
+    return GoogleMap(
+      initialCameraPosition: CameraPosition(
+        target: initialCenter,
+        zoom: initialZoom,
       ),
-      children: [
-        TileLayer(
-          urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-          userAgentPackageName: 'com.example.crewapp',
-          tileProvider: NetworkTileProvider(),    // 禁用磁盘缓存（如果不需要可删）
-        ),
-        ...children,
-      ],
+      onMapCreated: (controller) {
+        onMapCreated?.call(controller);
+        onMapReady?.call();
+      },
+      onLongPress: onLongPress,
+      markers: markers,
+      myLocationButtonEnabled: false,
+      myLocationEnabled: false,
+      zoomControlsEnabled: false,
+      mapToolbarEnabled: false,
+      compassEnabled: false,
     );
   }
 }
-
 

--- a/lib/features/events/presentation/map/widgets/markers_layer.dart
+++ b/lib/features/events/presentation/map/widgets/markers_layer.dart
@@ -1,40 +1,36 @@
 // widgets/markers_layer.dart
 import 'package:crew_app/features/events/data/event.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
-
-class MarkersLayer extends StatelessWidget {
-  final List<Marker> markers;
-  const MarkersLayer({super.key, required this.markers});
+class MarkersLayer {
+  final Set<Marker> markers;
+  const MarkersLayer({required this.markers});
 
   factory MarkersLayer.fromEvents({
     required List<Event> events,
     required LatLng? userLoc,
     required void Function(Event) onEventTap,
   }) {
-    final list = <Marker>[
-      ...events.map((ev) => Marker(
-            width: 80,
-            height: 80,
-            point: LatLng(ev.latitude, ev.longitude),
-            child: GestureDetector(
-              onTap: () => onEventTap(ev),
-              child: const Icon(Icons.location_pin, color: Colors.red, size: 40),
-            ),
-          )),
-      if (userLoc != null)
+    final markers = <Marker>{
+      for (final ev in events)
         Marker(
-          point: userLoc,
-          width: 80,
-          height: 80,
-          child: const Icon(Icons.location_pin, color: Colors.blue, size: 40),
+          markerId: MarkerId('event_${ev.id}'),
+          position: LatLng(ev.latitude, ev.longitude),
+          infoWindow: InfoWindow(title: ev.title, snippet: ev.location),
+          onTap: () => onEventTap(ev),
         ),
-    ];
-    return MarkersLayer(markers: list);
-  }
+    };
 
-  @override
-  Widget build(BuildContext context) => MarkerLayer(markers: markers);
+    if (userLoc != null) {
+      markers.add(
+        Marker(
+          markerId: const MarkerId('user_location'),
+          position: userLoc,
+          icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueAzure),
+        ),
+      );
+    }
+
+    return MarkersLayer(markers: markers);
+  }
 }

--- a/lib/features/events/state/events_providers.dart
+++ b/lib/features/events/state/events_providers.dart
@@ -4,7 +4,7 @@ import 'package:crew_app/core/state/di/providers.dart';
 import 'package:crew_app/features/events/data/event.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 final eventsProvider =
     AsyncNotifierProvider.autoDispose<EventsCtrl, List<Event>>(EventsCtrl.new);

--- a/lib/features/events/state/user_location_provider.dart
+++ b/lib/features/events/state/user_location_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 final userLocationProvider =
     AsyncNotifierProvider<UserLocationCtrl, LatLng?>(UserLocationCtrl.new);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -555,14 +555,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_map:
-    dependency: "direct main"
-    description:
-      name: flutter_map
-      sha256: "391e7dc95cc3f5190748210a69d4cfeb5d8f84dcdfa9c3235d0a9d7742ccb3f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.2.2"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -997,14 +989,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
-  latlong2:
-    dependency: "direct main"
-    description:
-      name: latlong2
-      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,10 +40,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.9.0
   json_annotation: ^4.9.0
-  flutter_map: ^8.2.1
   geolocator: ^14.0.2
   geocoding: ^4.0.0
-  latlong2: ^0.9.1    
   firebase_core: ^4.1.0 
   firebase_auth: ^6.0.1
   firebase_ui_auth: ^3.0.0


### PR DESCRIPTION
## Summary
- switch the events map page to the Google Maps widget with animated camera control and marker handling
- update map utilities, sheets, and providers to use `google_maps_flutter` types and marker construction
- remove the old `flutter_map`/`latlong2` dependencies from the project configuration

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e597382704832cbd565c47089cd327