### PR TITLE
Switch overlay navigation to header buttons

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,14 +1,14 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:crew_app/features/events/presentation/group_chat/group_chat_page.dart';
 import 'package:crew_app/l10n/generated/app_localizations.dart';
+import 'package:crew_app/shared/playground/profile/profile_page.dart';
 import 'package:crew_app/shared/widgets/scroll_activity_listener.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../features/events/presentation/events_list/events_list_page.dart';
 import '../features/events/presentation/map/events_map_page.dart';
+import '../features/trips/presentation/create_road_trip_page.dart';
 import 'state/app_overlay_provider.dart';
 
 class App extends ConsumerStatefulWidget {
@@ -154,12 +154,20 @@ class _AppState extends ConsumerState<App> {
               children: [
                 ScrollActivityListener(
                   onScrollActivityChanged: _handleScrollActivity,
-                  child: const EventsListPage(),
+                  child: CreateRoadTripPage(
+                    onClose: () {
+                      ref.read(appOverlayIndexProvider.notifier).state = 1;
+                    },
+                  ),
                 ),
                 const SizedBox.expand(),
                 ScrollActivityListener(
                   onScrollActivityChanged: _handleScrollActivity,
-                  child: const GroupChatPage(),
+                  child: ProfilePage(
+                    onClose: () {
+                      ref.read(appOverlayIndexProvider.notifier).state = 1;
+                    },
+                  ),
                 ),
               ],
             ),

--- a/lib/features/events/presentation/map/events_map_page.dart
+++ b/lib/features/events/presentation/map/events_map_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:crew_app/app/state/app_overlay_provider.dart';
 import 'package:crew_app/core/config/environment.dart';
 import 'package:crew_app/shared/widgets/sheets/legal_sheet/presentation/widgets/disclaimer_sheet.dart';
 import 'package:crew_app/shared/widgets/sheets/legal_sheet/state/disclaimer_providers.dart';
@@ -120,6 +121,7 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
         onSearch: _onSearchSubmitted,
         onChanged: _onQueryChanged,
         onClear: _onSearchClear,
+        onCreateRoadTripTap: _onCreateRoadTripTap,
         onAvatarTap: _onAvatarTap,
         tags: _quickTags,
         selected: _selectedTags,
@@ -246,12 +248,24 @@ class _EventsMapPageState extends ConsumerState<EventsMapPage> {
     _showEventCard(event);
   }
 
-  void _onAvatarTap(bool authed) {
-    if (authed) {
-      Navigator.pushNamed(context, '/profile');
-    } else {
-      Navigator.pushNamed(context, '/profile');
+  void _onCreateRoadTripTap() {
+    if (_searchFocusNode.hasFocus) {
+      _searchFocusNode.unfocus();
     }
+    if (_showSearchResults) {
+      setState(() => _showSearchResults = false);
+    }
+    ref.read(appOverlayIndexProvider.notifier).state = 0;
+  }
+
+  void _onAvatarTap(bool _) {
+    if (_searchFocusNode.hasFocus) {
+      _searchFocusNode.unfocus();
+    }
+    if (_showSearchResults) {
+      setState(() => _showSearchResults = false);
+    }
+    ref.read(appOverlayIndexProvider.notifier).state = 2;
   }
 
   Future<bool> _ensureDisclaimerAccepted() async {

--- a/lib/features/events/presentation/map/widgets/search_event_appbar.dart
+++ b/lib/features/events/presentation/map/widgets/search_event_appbar.dart
@@ -12,6 +12,7 @@ class SearchEventAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.onSearch,
     required this.onChanged,
     required this.onClear,
+    required this.onCreateRoadTripTap,
     required this.onAvatarTap,
     required this.tags,
     required this.selected,
@@ -29,6 +30,7 @@ class SearchEventAppBar extends StatelessWidget implements PreferredSizeWidget {
   final void Function(String keyword) onSearch;
   final ValueChanged<String> onChanged;
   final VoidCallback onClear;
+  final VoidCallback onCreateRoadTripTap;
   final void Function(bool authed) onAvatarTap;
   final List<String> tags;
   final Set<String> selected;
@@ -95,7 +97,10 @@ class SearchEventAppBar extends StatelessWidget implements PreferredSizeWidget {
                           borderRadius: BorderRadius.circular(24),
                           borderSide: BorderSide.none,
                         ),
-                        prefixIcon: const Icon(Icons.my_location_outlined),
+                        prefixIcon: IconButton(
+                          icon: const Icon(Icons.add_circle_outline),
+                          onPressed: onCreateRoadTripTap,
+                        ),
                         suffixIconConstraints:
                             const BoxConstraints(minWidth: 96, minHeight: 44),
                         suffixIcon: Row(

--- a/lib/features/trips/presentation/create_road_trip_page.dart
+++ b/lib/features/trips/presentation/create_road_trip_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class CreateRoadTripPage extends StatelessWidget {
+  const CreateRoadTripPage({
+    super.key,
+    required this.onClose,
+  });
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('创建活动行程'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: onClose,
+        ),
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            '在这里规划你的旅行或活动。\n稍后将补充具体内容。',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/playground/profile/profile_page.dart
+++ b/lib/shared/playground/profile/profile_page.dart
@@ -11,7 +11,9 @@ import '../../../core/state/auth/auth_providers.dart';
 import '../../../core/state/user/avatar/avatar_provider.dart';
 
 class ProfilePage extends ConsumerWidget {
-  const ProfilePage({super.key});
+  const ProfilePage({super.key, this.onClose});
+
+  final VoidCallback? onClose;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -27,9 +29,7 @@ class ProfilePage extends ConsumerWidget {
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.close),
-          onPressed: () {
-            Navigator.of(context).pop(); // 关闭页面
-          },
+          onPressed: onClose ?? () => Navigator.of(context).pop(),
         ),
       ),
       body: RefreshIndicator(


### PR DESCRIPTION
## Summary
- replace the overlay pages with a road trip creator and profile screen that can return to the map overlay
- wire the map search header buttons to flip between the overlay pages instead of relying on the bottom navigation bar
- allow the profile page to close via a custom callback and add a placeholder road trip creation page

## Testing
- `flutter analyze` *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5991dd8e4832c91d6d055241e925d